### PR TITLE
Cleanup and fix acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test:
 
 testacc:
 	@echo "==> Running acceptance tests..."
-	TF_ACC=1 AAP_HOST="https://localhost:8043" AAP_INSECURE_SKIP_VERIFY=true go test -v ./...
+	TF_ACC=1 AAP_HOST="https://localhost:8043" AAP_INSECURE_SKIP_VERIFY=true go test -count=1 -v ./...
 
 gofmt:
 	@echo "==> Format code using gofmt..."

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ default: build
 
 build:
 	@echo "==> Building package..."
-	go build ./...
+	go build
 
 lint:
 	@echo "==> Checking source code against linters..."

--- a/README.md
+++ b/README.md
@@ -47,25 +47,13 @@ export AAP_USERNAME=<your admin username>
 export AAP_PASSWORD=<your admin password>
 ```
 
-Then you can run acceptance tests with `make testacc`.
+In order to run the acceptance tests for the job resource, you must have a working job template already in your AAP instance. The job template must be set to require an inventory on launch. Export the id of this job template:
 
-Following environment variable must be exported in order to run acceptance tests for job, host and group resources:
-
-```bash
-export AAP_TEST_INVENTORY_ID=<the ID of an inventory in your AAP instance>
-```
-
-In addition, acceptance tests will fail unless the following environment variables are also set:
-
-- for the job resource
 ```bash
 export AAP_TEST_JOB_TEMPLATE_ID=<the ID of a job template in your AAP instance>
 ```
 
-- for the host resource
-```bash
-export AAP_TEST_GROUP_ID=<the ID of a group in your AAP instance>
-```
+Then you can run acceptance tests with `make testacc`.
 
 **WARNING**: running acceptance tests for the job resource will launch several jobs for the specified job template. It's strongly recommended that you create a "check" type job template for testing to ensure the launched jobs do not deploy any actual infrastructure.
 

--- a/internal/provider/inventory_data_source_test.go
+++ b/internal/provider/inventory_data_source_test.go
@@ -96,7 +96,6 @@ func TestInventoryDataSourceParseHttpResponse(t *testing.T) {
 }
 
 func TestAccInventoryDataSource(t *testing.T) {
-	var inventory InventoryAPIModel
 	randomName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
@@ -107,14 +106,11 @@ func TestAccInventoryDataSource(t *testing.T) {
 			{
 				Config: testAccInventoryDataSource(randomName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					// Check the existence of the created inventory and store its values in the inventory model
-					testAccCheckInventoryResourceExists("aap_inventory.test", &inventory),
-					// Verify the data source values against the stored resource values
-					resource.TestCheckResourceAttrPtr("data.aap_inventory.test", "name", &inventory.Name),
-					resource.TestCheckResourceAttr("data.aap_inventory.test", "organization", "1"),
-					resource.TestCheckResourceAttrPtr("data.aap_inventory.test", "description", &inventory.Description),
-					resource.TestCheckResourceAttrPtr("data.aap_inventory.test", "variables", &inventory.Variables),
-					resource.TestCheckResourceAttrPtr("data.aap_inventory.test", "url", &inventory.Url),
+					resource.TestCheckResourceAttrPair("aap_inventory.test", "name", "data.aap_inventory.test", "name"),
+					resource.TestCheckResourceAttrPair("aap_inventory.test", "organization", "data.aap_inventory.test", "organization"),
+					resource.TestCheckResourceAttrPair("aap_inventory.test", "description", "data.aap_inventory.test", "description"),
+					resource.TestCheckResourceAttrPair("aap_inventory.test", "variables", "data.aap_inventory.test", "variables"),
+					resource.TestCheckResourceAttrPair("aap_inventory.test", "url", "data.aap_inventory.test", "url"),
 				),
 			},
 		},

--- a/internal/provider/job_resource_test.go
+++ b/internal/provider/job_resource_test.go
@@ -397,7 +397,7 @@ func testAccCheckJobPause(name string) resource.TestCheckFunc {
 			return fmt.Errorf("job (%s) not found in state", name)
 		}
 		i := 0
-		for i < 10 {
+		for i < 20 {
 			i += 1
 			body, err := testGetResource(job.Primary.Attributes["url"])
 			if err != nil {


### PR DESCRIPTION
The biggest change here is to remove the need for setting up an inventory or group before running acceptance tests. In addition, a new function has been added to the acceptance tests for the job resource to ensure the associated inventory resource is only deleted after the job has finished running. Without this, the destroy step will fail. The supplied job template *must* be set to require an inventory on launch, otherwise the inventory that's passed is not used.

Closes #13 