### PR TITLE
Update goreleaser version in workflow - .goreleaser.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,10 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
+          distribution: goreleaser
+          version: '~> v2'
           args: release --clean
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.


### PR DESCRIPTION
https://github.com/ansible/terraform-provider-aap/actions/runs/12874929078/job/35895308565 release fails with error
```
error=only configurations files on version: 1 are supported, yours is version: 2, please update your configuration
Error: The process '/opt/hostedtoolcache/goreleaser-action/1.26.2/x64/goreleaser' failed with exit code 1
```

pin to use a v2 major version instread of downloading 1.26.2

referred https://github.com/marketplace/actions/goreleaser-action#workflow 
https://github.com/goreleaser/goreleaser-action/releases/tag/v5.1.0 