### PR TITLE
Add support for the wait_for_completed flag to aap_job resource

### DIFF
--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -4,6 +4,8 @@ description: |-
   Launches an AAP job.
   A job is launched only when the resource is first created or when the resource is changed. The triggers argument can be used to launch a new job based on any arbitrary value.
   This resource always creates a new job in AAP. A destroy will not delete a job created by this resource, it will only remove the resource from the state.
+  Moreover, you can set wait_for_completion to true, then Terraform will wait until this job is created and reaches any final state before continuing. This parameter works in both create and update operations.
+  You can also tweak wait_for_completion_timeout_seconds to control the timeout limit.
 ---
 
 # aap_job (Resource)
@@ -14,7 +16,11 @@ A job is launched only when the resource is first created or when the resource i
 
 This resource always creates a new job in AAP. A destroy will not delete a job created by this resource, it will only remove the resource from the state.
 
--> **Note** To pass an inventory to an aap_job resource, the underlying job template *must* have been conigured to prompt for the inventory on launch.
+Moreover, you can set `wait_for_completion` to true, then Terraform will wait until this job is created and reaches any final state before continuing. This parameter works in both create and update operations.
+
+You can also tweak `wait_for_completion_timeout_seconds` to control the timeout limit.
+
+-> **Note** To pass an inventory to an aap_job resource, the underlying job template *must* have been configured to prompt for the inventory on launch.
 
 !> **Warning** If an AAP Job launched by this resource is deleted from AAP, the resource will be removed from the state and a new job will be created to replace it.
 
@@ -86,6 +92,13 @@ resource "aap_job" "sample_xyz" {
   extra_vars      = "os: Linux\nautomation: ansible-devel"
 }
 
+resource "aap_job" "sample_wait_for_completion" {
+  job_template_id                     = 9
+  inventory_id                        = aap_inventory.my_inventory.id
+  wait_for_completion                 = true
+  wait_for_completion_timeout_seconds = 120
+}
+
 output "job_foo" {
   value = aap_job.sample_foo
 }
@@ -120,6 +133,8 @@ output "job_xyz" {
 - `extra_vars` (String) Extra Variables. Must be provided as either a JSON or YAML string.
 - `inventory_id` (Number) Identifier for the inventory where job should be created in. If not provided, the job will be created in the default inventory.
 - `triggers` (Map of String) Map of arbitrary keys and values that, when changed, will trigger a creation of a new Job on AAP. Use 'terraform taint' if you want to force the creation of a new job without changing this value.
+- `wait_for_completion` (Boolean) When this is set to `true`, Terraform will wait until this aap_job resource is created, reaches any final status and then, proceeds with the following resource operation
+- `wait_for_completion_timeout_seconds` (Number) Sets the maximum amount of seconds Terraform will wait before timing out the updates, and the job creation will fail. Default value of `120`
 
 ### Read-Only
 

--- a/examples/resources/aap_job/resource.tf
+++ b/examples/resources/aap_job/resource.tf
@@ -62,6 +62,13 @@ resource "aap_job" "sample_xyz" {
   extra_vars      = "os: Linux\nautomation: ansible-devel"
 }
 
+resource "aap_job" "sample_wait_for_completion" {
+  job_template_id                     = 9
+  inventory_id                        = aap_inventory.my_inventory.id
+  wait_for_completion                 = true
+  wait_for_completion_timeout_seconds = 120
+}
+
 output "job_foo" {
   value = aap_job.sample_foo
 }

--- a/internal/provider/job_resource_test.go
+++ b/internal/provider/job_resource_test.go
@@ -99,6 +99,16 @@ func TestJobResourceCreateRequestBody(t *testing.T) {
 			},
 			expected: []byte(`{"inventory": 3}`),
 		},
+		{
+			name: "wait_for_completed parameters",
+			input: JobResourceModel{
+				InventoryID:              basetypes.NewInt64Value(3),
+				TemplateID:               types.Int64Value(1),
+				WaitForCompletion:        basetypes.NewBoolValue(true),
+				WaitForCompletionTimeout: basetypes.NewInt64Value(60),
+			},
+			expected: []byte(`{"inventory":3}`),
+		},
 	}
 
 	for _, tc := range testTable {

--- a/templates/resources/job.md.tmpl
+++ b/templates/resources/job.md.tmpl
@@ -8,7 +8,7 @@ description: |-
 
 {{ .Description | trimspace }}
 
--> **Note** To pass an inventory to an aap_job resource, the underlying job template *must* have been conigured to prompt for the inventory on launch.
+-> **Note** To pass an inventory to an aap_job resource, the underlying job template *must* have been configured to prompt for the inventory on launch.
 
 !> **Warning** If an AAP Job launched by this resource is deleted from AAP, the resource will be removed from the state and a new job will be created to replace it.
 


### PR DESCRIPTION
Letting the user wait on aap_job resources to complete before continuing creating aap resources. Extra parameters allow the user to tweak the timeout of this wait operation