### PR TITLE
Disabling dupl linter due to false positives

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,7 @@ linters:
   disable-all: true
   enable:
     - dogsled
-    - dupl
+    # - dupl  Terraform framework uses similar patterns so this linter creates a lot of false positives
     - errcheck
     - exportloopref
     - gocheckcompilerdirectives


### PR DESCRIPTION
The provider is using a lot of boilerplate code. This linter is currently picking up on functions that are duplicate but are apart of the boilerplate. In the background we are looking at ways to de duplicate the code. In the meantime lets disable the linter.