### PR TITLE
client http error handling improvement needed

### DIFF
--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -152,6 +152,10 @@ func (c *AAPClient) Create(path string, data io.Reader) ([]byte, diag.Diagnostic
 func (c *AAPClient) GetWithStatus(path string) ([]byte, diag.Diagnostics, int) {
 	getResponse, body, err := c.doRequest("GET", path, nil)
 	diags := ValidateResponse(getResponse, body, err, []int{http.StatusOK})
+	if getResponse == nil {
+		diags.AddError("HTTP response error", "No HTTP response from server")
+		return body, diags, http.StatusInternalServerError
+	}
 	return body, diags, getResponse.StatusCode
 }
 


### PR DESCRIPTION
With this change I now get:

`=== RUN   TestAccGroupResource
    group_resource_test.go:181: Step 1/3, expected an error with pattern, no match on: Error running pre-apply plan: exit status 1
        
        Error: Invalid provider configuration
        
        Provider "registry.terraform.io/hashicorp/aap" requires explicit
        configuration. Add a provider block to the root module and configure the
        provider's required arguments as described in the provider documentation.
        
        
        Error: Client request error
        
          with provider["registry.terraform.io/hashicorp/aap"],
          on <empty> line 0:
          (source code not available)
        
        Get "https://localhost:8043/api/": dial tcp [::1]:8043: connect: connection
        refused
        
        Error: HTTP response error
        
          with provider["registry.terraform.io/hashicorp/aap"],
          on <empty> line 0:
          (source code not available)
        
        No HTTP response from server`
        
   Instead of 
   
   `=== RUN   TestAccGroupResource
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xe58c00]

goroutine 178 [running]:
github.com/ansible/terraform-provider-aap/internal/provider.(*AAPClient).GetWithStatus(0x4187c5?, {0x10d0646?, 0x0?})
	/home/arestlel/repos/terraform-provider-aap/internal/provider/client.go:155 +0xa0
github.com/ansible/terraform-provider-aap/internal/provider.(*AAPClient).Get(0x6e1200?, {0x10d0646?, 0x0?})
	/home/arestlel/repos/terraform-provider-aap/internal/provider/client.go:159 +0x18
github.com/ansible/terraform-provider-aap/internal/provider.readApiEndpoint({0x1299578, 0xc000420080})
	/home/arestlel/repos/terraform-provider-aap/internal/provider/client.go:45 +0x42
github.com/ansible/terraform-provider-aap/internal/provider.(*AAPClient).setApiEndpoint(0xc000420080)
	/home/arestlel/repos/terraform-provider-aap/internal/provider/client.go:100 +0x26
github.com/ansible/terraform-provider-aap/internal/provider.NewClient({0xc00003c029?, 0xc0005d7430?}, 0xc0001fc2a0, 0xc0001fc2b0, 0x1, 0x5)
	/home/arestlel/repos/terraform-provider-aap/internal/provider/client.go:95 +0x1c5
github.com/ansible/terraform-provider-aap/internal/provider.(*aapProvider).Configure(0xc000070f08?, {0x12935f8, 0xc0004d2810}, {{0xc000122a30, 0x6}, {{{0x1299af8, 0xc0004d2de0}, {0xf6e8a0, 0xc0004d2db0}}, {0x129bd48, ...}}, ...}, ...)
	/home/arestlel/repos/terraform-provider-aap/internal/provider/provider.go:135 +0x3a8
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).ConfigureProvider(0xc0004566c8, {0x12935f8, 0xc0004d2810}, 0xc0002c3cc0, 0xc0002c3c70)
	/home/arestlel/.gvm/pkgsets/go1.23.0/global/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.13.0/internal/fwserver/server_configureprovider.go:18 +0x132
github.com/hashicorp/terraform-plugin-framework/internal/proto6server.(*Server).ConfigureProvider(0xc0004566c8, {0x12935f8?, 0xc0004d2750?}, 0xc0002a9e00)
	/home/arestlel/.gvm/pkgsets/go1.23.0/global/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.13.0/internal/proto6server/server_configureprovider.go:39 +0x2a5
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).ConfigureProvider(0xc0003ac3c0, {0x12935f8?, 0xc0001bfb60?}, 0xc0002c39a0)
	/home/arestlel/.gvm/pkgsets/go1.23.0/global/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov6/tf6server/server.go:559 +0x342
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_ConfigureProvider_Handler({0x10aaa60, 0xc0003ac3c0}, {0x12935f8, 0xc0001bfb60}, 0xc0003b7780, 0x0)
	/home/arestlel/.gvm/pkgsets/go1.23.0/global/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:557 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000460600, {0x12935f8, 0xc0001bfb00}, 0xc0004c8120, 0xc000395080, 0x1a12f90, 0x0)
	/home/arestlel/.gvm/pkgsets/go1.23.0/global/pkg/mod/google.golang.org/grpc@v1.69.4/server.go:1392 +0xfc3
google.golang.org/grpc.(*Server).handleStream(0xc000460600, {0x1294308, 0xc0003dab60}, 0xc0004c8120)
	/home/arestlel/.gvm/pkgsets/go1.23.0/global/pkg/mod/google.golang.org/grpc@v1.69.4/server.go:1802 +0xbaa
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	/home/arestlel/.gvm/pkgsets/go1.23.0/global/pkg/mod/google.golang.org/grpc@v1.69.4/server.go:1030 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 142
	/home/arestlel/.gvm/pkgsets/go1.23.0/global/pkg/mod/google.golang.org/grpc@v1.69.4/server.go:1041 +0x125
FAIL	github.com/ansible/terraform-provider-aap/internal/provider	0.109s
`