### PR TITLE
Create customModifier WarnIfDefaultInt64Used

### DIFF
--- a/internal/provider/customModifiers.go
+++ b/internal/provider/customModifiers.go
@@ -8,31 +8,31 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 )
 
-type warnIfDefaultUsedInt64Modifier struct{
-  attributeName string
-  releaseVersion string
+type warnIfDefaultUsedInt64Modifier struct {
+	attributeName  string
+	releaseVersion string
 }
 
 func (m warnIfDefaultUsedInt64Modifier) Description(ctx context.Context) string {
-  return fmt.Sprintf("Warns if the default value for '%s' is used during plan.", m.attributeName)
+	return fmt.Sprintf("Warns if the default value for '%s' is used during plan.", m.attributeName)
 }
 
 func (m warnIfDefaultUsedInt64Modifier) MarkdownDescription(ctx context.Context) string {
-  return m.Description(ctx)
+	return m.Description(ctx)
 }
 
 func (m warnIfDefaultUsedInt64Modifier) PlanModifyInt64(ctx context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
-  if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
-    resp.Diagnostics.Append(diag.NewWarningDiagnostic(
-      "Default vaule Used",
-      fmt.Sprintf("The default value for %s is being used. %s will be a required value in release %s", m.attributeName, m.attributeName, m.releaseVersion),
-    ))
-  }
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		resp.Diagnostics.Append(diag.NewWarningDiagnostic(
+			"Default vaule Used",
+			fmt.Sprintf("The default value for %s is being used. %s will be a required value in release %s", m.attributeName, m.attributeName, m.releaseVersion),
+		))
+	}
 }
 
 func WarnIfDefaultInt64Used(attributeName string, releaseVersion string) planmodifier.Int64 {
-  return warnIfDefaultUsedInt64Modifier{
-    attributeName: attributeName,
-    releaseVersion: releaseVersion,
-  }
+	return warnIfDefaultUsedInt64Modifier{
+		attributeName:  attributeName,
+		releaseVersion: releaseVersion,
+	}
 }

--- a/internal/provider/customModifiers.go
+++ b/internal/provider/customModifiers.go
@@ -1,0 +1,38 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+type warnIfDefaultUsedInt64Modifier struct{
+  attributeName string
+  releaseVersion string
+}
+
+func (m warnIfDefaultUsedInt64Modifier) Description(ctx context.Context) string {
+  return fmt.Sprintf("Warns if the default value for '%s' is used during plan.", m.attributeName)
+}
+
+func (m warnIfDefaultUsedInt64Modifier) MarkdownDescription(ctx context.Context) string {
+  return m.Description(ctx)
+}
+
+func (m warnIfDefaultUsedInt64Modifier) PlanModifyInt64(ctx context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
+  if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+    resp.Diagnostics.Append(diag.NewWarningDiagnostic(
+      "Default vaule Used",
+      fmt.Sprintf("The default value for %s is being used. %s will be a required value in release %s", m.attributeName, m.attributeName, m.releaseVersion),
+    ))
+  }
+}
+
+func WarnIfDefaultInt64Used(attributeName string, releaseVersion string) planmodifier.Int64 {
+  return warnIfDefaultUsedInt64Modifier{
+    attributeName: attributeName,
+    releaseVersion: releaseVersion,
+  }
+}

--- a/internal/provider/customModifiers.go
+++ b/internal/provider/customModifiers.go
@@ -13,7 +13,7 @@ type warnIfDefaultUsedInt64Modifier struct {
 	releaseVersion string
 }
 
-func (m warnIfDefaultUsedInt64Modifier) Description(ctx context.Context) string {
+func (m warnIfDefaultUsedInt64Modifier) Description(_ context.Context) string {
 	return fmt.Sprintf("Warns if the default value for '%s' is used during plan.", m.attributeName)
 }
 
@@ -21,7 +21,7 @@ func (m warnIfDefaultUsedInt64Modifier) MarkdownDescription(ctx context.Context)
 	return m.Description(ctx)
 }
 
-func (m warnIfDefaultUsedInt64Modifier) PlanModifyInt64(ctx context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
+func (m warnIfDefaultUsedInt64Modifier) PlanModifyInt64(_ context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		resp.Diagnostics.Append(diag.NewWarningDiagnostic(
 			"Default vaule Used",

--- a/internal/provider/inventory_resource.go
+++ b/internal/provider/inventory_resource.go
@@ -98,6 +98,7 @@ func (r *InventoryResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Optional: true,
 				Default:  int64default.StaticInt64(1),
 				PlanModifiers: []planmodifier.Int64{
+					WarnIfDefaultInt64Used("organization", "2.0.0"),
 					int64planmodifier.UseStateForUnknown(),
 				},
 				Description: "Identifier for the organization the inventory should be created in. " +


### PR DESCRIPTION
I created a custom plan modifier to warn when using the default from organization in inventory resource

Here is what terraform apply returns when organization is omitted :
```
Plan: 4 to add, 0 to change, 0 to destroy.
╷
│ Warning: Default vaule Used
│ 
│   with aap_inventory.default,
│   on main.tf line 18, in resource "aap_inventory" "default":
│   18: resource "aap_inventory" "default" {
│ 
│ The default value for organization is being used. organization will be a required value in release
│ 2.0.0
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.
```