### PR TITLE
Add BaseDataSourceModel and BaseDataSource structs with refactored functions

### DIFF
--- a/internal/provider/general_api_models.go
+++ b/internal/provider/general_api_models.go
@@ -1,5 +1,20 @@
 package provider
 
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+
+	"github.com/ansible/terraform-provider-aap/internal/provider/customtypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	tfpath "github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
 type SummaryFieldsAPIModel struct {
 	Organization SummaryAPIModel `json:"organization,omitempty"`
 	Inventory    SummaryAPIModel `json:"inventory,omitempty"`
@@ -15,4 +30,228 @@ type SummaryAPIModel struct {
 
 type RelatedAPIModel struct {
 	NamedUrl string `json:"named_url,omitempty"`
+}
+
+// A base struct to represent the DataSource model so new Data Sources can
+// extend it as needed.
+type BaseDataSourceModel struct {
+	Id               types.Int64                      `tfsdk:"id"`
+	Name             types.String                     `tfsdk:"name"`
+	Organization     types.Int64                      `tfsdk:"organization"`
+	OrganizationName types.String                     `tfsdk:"organization_name"`
+	Url              types.String                     `tfsdk:"url"`
+	NamedUrl         types.String                     `tfsdk:"named_url"`
+	Description      types.String                     `tfsdk:"description"`
+	Variables        customtypes.AAPCustomStringValue `tfsdk:"variables"`
+}
+
+// This function allows us to parse the incoming data in HTTP requests from the API
+// into the BaseDataSourceModel instances.
+func (d *BaseDataSourceModel) ParseHttpResponse(body []byte) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// Unmarshal the JSON response
+	var apiWorkflowJobTemplate WorkflowJobTemplateAPIModel
+	err := json.Unmarshal(body, &apiWorkflowJobTemplate)
+	if err != nil {
+		diags.AddError("Error parsing JSON response from AAP", err.Error())
+		return diags
+	}
+
+	// Map response to the WorkflowJobTemplate datesource schema
+	d.Id = types.Int64Value(apiWorkflowJobTemplate.Id)
+	d.Organization = types.Int64Value(apiWorkflowJobTemplate.Organization)
+	d.OrganizationName = ParseStringValue(apiWorkflowJobTemplate.SummaryFields.Organization.Name)
+	d.Url = ParseStringValue(apiWorkflowJobTemplate.Url)
+	d.NamedUrl = ParseStringValue(apiWorkflowJobTemplate.Related.NamedUrl)
+	d.Name = ParseStringValue(apiWorkflowJobTemplate.Name)
+	d.Description = ParseStringValue(apiWorkflowJobTemplate.Description)
+	d.Variables = ParseAAPCustomStringValue(apiWorkflowJobTemplate.Variables)
+
+	return diags
+}
+
+type StringDescriptions struct {
+	ApiEntitySlug         string
+	DescriptiveEntityName string
+	MetadataEntitySlug    string
+}
+
+// A struct to represent a base DataSource object, with a client and the slug name of
+// the API entity.
+type BaseDataSource struct {
+	client ProviderHTTPClient
+	StringDescriptions
+}
+
+// Constructs a new BaseDataSource object provided with a client instance (usually
+// initialized to nil, it will be later configured calling the Configure function)
+// and an apiEntitySlug string indicating the entity path name to consult the API.
+func NewBaseDataSource(client ProviderHTTPClient, stringDescriptions StringDescriptions) *BaseDataSource {
+	return &BaseDataSource{
+		client:             client,
+		StringDescriptions: stringDescriptions,
+	}
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (d *BaseDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state BaseDataSourceModel
+	var diags diag.Diagnostics
+
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	uri := path.Join(d.client.getApiEndpoint(), d.ApiEntitySlug)
+	resourceURL, err := ReturnAAPNamedURL(state.Id, state.Name, state.OrganizationName, uri)
+	if err != nil {
+		resp.Diagnostics.AddError("Minimal Data Not Supplied", "Expected either [id] or [name + organization_name] pair")
+		return
+	}
+
+	readResponseBody, diags := d.client.Get(resourceURL)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = state.ParseHttpResponse(readResponseBody)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	// Set state
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Configure adds the provider configured client to the data source.
+func (d *BaseDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*AAPClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *AAPClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.client = client
+}
+
+func (d *BaseDataSource) ConfigValidators(_ context.Context) []datasource.ConfigValidator {
+	// You have at least an id or a name + organization_name pair
+	return []datasource.ConfigValidator{
+		datasourcevalidator.Any(
+			datasourcevalidator.AtLeastOneOf(
+				tfpath.MatchRoot("id")),
+			datasourcevalidator.RequiredTogether(
+				tfpath.MatchRoot("name"),
+				tfpath.MatchRoot("organization_name")),
+		),
+	}
+}
+
+func (d *BaseDataSource) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+	var data BaseDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if IsValueProvided(data.Id) {
+		return
+	}
+
+	if IsValueProvided(data.Name) && IsValueProvided(data.OrganizationName) {
+		return
+	}
+
+	if !IsValueProvided(data.Id) && !IsValueProvided(data.Name) {
+		resp.Diagnostics.AddAttributeWarning(
+			tfpath.Root("id"),
+			"Missing Attribute Configuration",
+			"Expected either [id] or [name + organization_name] pair",
+		)
+	}
+
+	if IsValueProvided(data.Name) && !IsValueProvided(data.OrganizationName) {
+		resp.Diagnostics.AddAttributeWarning(
+			tfpath.Root("organization_name"),
+			"Missing Attribute Configuration",
+			"Expected organization_name to be configured with name.",
+		)
+	}
+
+	if !IsValueProvided(data.Name) && IsValueProvided(data.OrganizationName) {
+		resp.Diagnostics.AddAttributeWarning(
+			tfpath.Root("name"),
+			"Missing Attribute Configuration",
+			"Expected name to be configured with organization_name.",
+		)
+	}
+}
+
+// Schema defines the schema fields for the data source.
+func (d *BaseDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.Int64Attribute{
+				Optional:    true,
+				Description: fmt.Sprintf("%s id", d.DescriptiveEntityName),
+			},
+			"organization": schema.Int64Attribute{
+				Computed:    true,
+				Description: fmt.Sprintf("Identifier for the organization to which the %s belongs", d.DescriptiveEntityName),
+			},
+			"organization_name": schema.StringAttribute{
+				Computed:    true,
+				Optional:    true,
+				Description: fmt.Sprintf("The name for the organization to which the %s belongs", d.DescriptiveEntityName),
+			},
+			"url": schema.StringAttribute{
+				Computed:    true,
+				Description: fmt.Sprintf("Url of the %s", d.DescriptiveEntityName),
+			},
+			"named_url": schema.StringAttribute{
+				Computed:    true,
+				Description: fmt.Sprintf("The Named Url of the %s", d.DescriptiveEntityName),
+			},
+			"name": schema.StringAttribute{
+				Computed:    true,
+				Optional:    true,
+				Description: fmt.Sprintf("Name of the %s", d.DescriptiveEntityName),
+			},
+			"description": schema.StringAttribute{
+				Computed:    true,
+				Description: fmt.Sprintf("Description of the %s", d.DescriptiveEntityName),
+			},
+			"variables": schema.StringAttribute{
+				Computed:   true,
+				CustomType: customtypes.AAPCustomStringType{},
+				Description: fmt.Sprintf("Variables of the %s. Will be either JSON or YAML string depending on how the "+
+					"variables were entered into AAP.", d.DescriptiveEntityName),
+			},
+		},
+		Description: fmt.Sprintf("Get an existing %s.", d.DescriptiveEntityName),
+	}
+}
+
+// Metadata returns the data source type name composing it from the provider type name and the
+// entity slug string passed in the constructor.
+func (d *BaseDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, d.MetadataEntitySlug)
 }

--- a/internal/provider/general_api_models.go
+++ b/internal/provider/general_api_models.go
@@ -44,8 +44,8 @@ type BaseEntityAPIModel struct {
 }
 
 // A base struct to represent the DataSource model so new Data Sources can
-// extend it as needed.
-type BaseDataSourceModel struct {
+// extend it as needed. No AAP organization fields.
+type BaseDataSourceModelWithOrg struct {
 	Id               types.Int64                      `tfsdk:"id"`
 	Name             types.String                     `tfsdk:"name"`
 	Organization     types.Int64                      `tfsdk:"organization"`
@@ -57,8 +57,8 @@ type BaseDataSourceModel struct {
 }
 
 // This function allows us to parse the incoming data in HTTP requests from the API
-// into the BaseDataSourceModel instances.
-func (d *BaseDataSourceModel) ParseHttpResponse(body []byte) diag.Diagnostics {
+// into the BaseDataSourceModelWithOrg instances.
+func (d *BaseDataSourceModelWithOrg) ParseHttpResponse(body []byte) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Unmarshal the JSON response
@@ -143,7 +143,7 @@ func (d *BaseDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 
 	// Read Terraform configuration data into the model
-	var state BaseDataSourceModel
+	var state BaseDataSourceModelWithOrg
 	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -241,7 +241,7 @@ func (d *BaseDataSource) ValidateConfig(ctx context.Context, req datasource.Vali
 		return
 	}
 
-	var data BaseDataSourceModel
+	var data BaseDataSourceModelWithOrg
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/general_api_models.go
+++ b/internal/provider/general_api_models.go
@@ -33,6 +33,16 @@ type RelatedAPIModel struct {
 	NamedUrl string `json:"named_url,omitempty"`
 }
 
+// A base struct for the entities API models. To be extended as needed.
+type BaseEntityAPIModel struct {
+	SummaryAPIModel `json:"summary_fields,omitempty"`
+	Organization    SummaryAPIModel `json:"organization,omitempty"`
+	Inventory       SummaryAPIModel `json:"inventory,omitempty"`
+	Url             string          `json:"url,omitempty"`
+	Variables       string          `json:"variables,omitempty"`
+	Related         RelatedAPIModel `json:"related,omitempty"`
+}
+
 // A base struct to represent the DataSource model so new Data Sources can
 // extend it as needed.
 type BaseDataSourceModel struct {
@@ -52,22 +62,22 @@ func (d *BaseDataSourceModel) ParseHttpResponse(body []byte) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Unmarshal the JSON response
-	var apiWorkflowJobTemplate WorkflowJobTemplateAPIModel
-	err := json.Unmarshal(body, &apiWorkflowJobTemplate)
+	var baseEntityAPIModel BaseEntityAPIModel
+	err := json.Unmarshal(body, &baseEntityAPIModel)
 	if err != nil {
 		diags.AddError("Error parsing JSON response from AAP", err.Error())
 		return diags
 	}
 
 	// Map response to the WorkflowJobTemplate datesource schema
-	d.Id = types.Int64Value(apiWorkflowJobTemplate.Id)
-	d.Organization = types.Int64Value(apiWorkflowJobTemplate.Organization)
-	d.OrganizationName = ParseStringValue(apiWorkflowJobTemplate.SummaryFields.Organization.Name)
-	d.Url = ParseStringValue(apiWorkflowJobTemplate.Url)
-	d.NamedUrl = ParseStringValue(apiWorkflowJobTemplate.Related.NamedUrl)
-	d.Name = ParseStringValue(apiWorkflowJobTemplate.Name)
-	d.Description = ParseStringValue(apiWorkflowJobTemplate.Description)
-	d.Variables = ParseAAPCustomStringValue(apiWorkflowJobTemplate.Variables)
+	d.Id = types.Int64Value(baseEntityAPIModel.Id)
+	d.Organization = types.Int64Value(baseEntityAPIModel.Organization.Id)
+	d.OrganizationName = ParseStringValue(baseEntityAPIModel.Organization.Name)
+	d.Url = ParseStringValue(baseEntityAPIModel.Url)
+	d.NamedUrl = ParseStringValue(baseEntityAPIModel.Related.NamedUrl)
+	d.Name = ParseStringValue(baseEntityAPIModel.Name)
+	d.Description = ParseStringValue(baseEntityAPIModel.Description)
+	d.Variables = ParseAAPCustomStringValue(baseEntityAPIModel.Variables)
 
 	return diags
 }

--- a/internal/provider/inventory_resource.go
+++ b/internal/provider/inventory_resource.go
@@ -301,11 +301,11 @@ func (r *InventoryResourceModel) generateRequestBody() ([]byte, diag.Diagnostics
 		Description:  r.Description.ValueString(),
 		Variables:    r.Variables.ValueString(),
 		SummaryFields: SummaryFieldsAPIModel{
-			Organization: SummaryAPIModel{
+			Organization: SummaryField{
 				Id:   organizationId,
 				Name: r.OrganizationName.ValueString(),
 			},
-			Inventory: SummaryAPIModel{
+			Inventory: SummaryField{
 				Id:   r.Id.ValueInt64(),
 				Name: r.Name.ValueString(),
 			},

--- a/internal/provider/inventory_resource_test.go
+++ b/internal/provider/inventory_resource_test.go
@@ -59,7 +59,7 @@ func TestInventoryResourceGenerateRequestBody(t *testing.T) {
 				Description:      types.StringUnknown(),
 				Variables:        customtypes.NewAAPCustomStringUnknown(),
 			},
-			expected: []byte(`{"id":0,"url":"","related":{},"summary_fields":{"organization":{"id":1,"name":""},"inventory":{"id":0,"name":""}},"organization":1}`),
+			expected: []byte(`{"organization":1,"summary_fields":{"organization":{"id":1,"name":""},"inventory":{"id":0,"name":""}},"related":{},"name":""}`),
 		},
 		{
 			name: "null values",
@@ -73,7 +73,7 @@ func TestInventoryResourceGenerateRequestBody(t *testing.T) {
 				Description:      types.StringNull(),
 				Variables:        customtypes.NewAAPCustomStringNull(),
 			},
-			expected: []byte(`{"id":0,"url":"","related":{},"summary_fields":{"organization":{"id":1,"name":""},"inventory":{"id":0,"name":""}},"organization":1}`),
+			expected: []byte(`{"organization":1,"summary_fields":{"organization":{"id":1,"name":""},"inventory":{"id":0,"name":""}},"related":{},"name":""}`),
 		},
 		{
 			name: "provided values",
@@ -87,7 +87,9 @@ func TestInventoryResourceGenerateRequestBody(t *testing.T) {
 				Variables:        customtypes.NewAAPCustomStringValue("{\"foo\": \"bar\", \"nested\": {\"foobar\": \"baz\"}}"),
 			},
 			expected: []byte(
-				`{"id":1,"name":"test inventory","description":"A test inventory for testing","url":"","related":{"named_url":"inventories/1"},"summary_fields":{"organization":{"id":2,"name":"test organization"},"inventory":{"id":1,"name":"test inventory"}},"variables":"{\"foo\": \"bar\", \"nested\": {\"foobar\": \"baz\"}}","organization":2}`,
+				`{"organization":2,"summary_fields":{"organization":{"id":2,"name":"test organization"},"inventory":{"id":1,"name":"test inventory"}},` +
+					`"related":{"named_url":"inventories/1"},"name":"test inventory","description":"A test inventory for testing",` +
+					`"variables":"{\"foo\": \"bar\", \"nested\": {\"foobar\": \"baz\"}}"}`,
 			),
 		},
 	}

--- a/internal/provider/inventory_resource_test.go
+++ b/internal/provider/inventory_resource_test.go
@@ -59,7 +59,7 @@ func TestInventoryResourceGenerateRequestBody(t *testing.T) {
 				Description:      types.StringUnknown(),
 				Variables:        customtypes.NewAAPCustomStringUnknown(),
 			},
-			expected: []byte(`{"organization":1,"summary_fields":{"organization":{"id":1,"name":""},"inventory":{"name":""}},"related":{},"name":""}`),
+			expected: []byte(`{"id":0,"url":"","related":{},"summary_fields":{"organization":{"id":1,"name":""},"inventory":{"id":0,"name":""}},"organization":1}`),
 		},
 		{
 			name: "null values",
@@ -73,7 +73,7 @@ func TestInventoryResourceGenerateRequestBody(t *testing.T) {
 				Description:      types.StringNull(),
 				Variables:        customtypes.NewAAPCustomStringNull(),
 			},
-			expected: []byte(`{"organization":1,"summary_fields":{"organization":{"id":1,"name":""},"inventory":{"name":""}},"related":{},"name":""}`),
+			expected: []byte(`{"id":0,"url":"","related":{},"summary_fields":{"organization":{"id":1,"name":""},"inventory":{"id":0,"name":""}},"organization":1}`),
 		},
 		{
 			name: "provided values",
@@ -87,9 +87,7 @@ func TestInventoryResourceGenerateRequestBody(t *testing.T) {
 				Variables:        customtypes.NewAAPCustomStringValue("{\"foo\": \"bar\", \"nested\": {\"foobar\": \"baz\"}}"),
 			},
 			expected: []byte(
-				`{"organization":2,"summary_fields":{"organization":{"id":2,"name":"test organization"},"inventory":{"id":1,"name":"test inventory"}},` +
-					`"related":{"named_url":"inventories/1"},"name":"test inventory","description":"A test inventory for testing",` +
-					`"variables":"{\"foo\": \"bar\", \"nested\": {\"foobar\": \"baz\"}}"}`,
+				`{"id":1,"name":"test inventory","description":"A test inventory for testing","url":"","related":{"named_url":"inventories/1"},"summary_fields":{"organization":{"id":2,"name":"test organization"},"inventory":{"id":1,"name":"test inventory"}},"variables":"{\"foo\": \"bar\", \"nested\": {\"foobar\": \"baz\"}}","organization":2}`,
 			),
 		},
 	}


### PR DESCRIPTION
These functions come from the different DataSource entities defined in other files. We saw an opportunity to refactor these repeated functions and common fields out to a new base struct.

This is the first part of the refactoring effort. There will be other PRs linked to this one later on removing the corresponding refactored code.

UPDATE:
In the `general_api_models.go` file you will find three different inheritance trees. All of these support the variants with and without AAP organization. So that we can better match the API's schemas to the Go struct fields.

- `BaseDetailAPIModel`, `BaseDetailAPIModelWithOrg`, and children/composed structs. These represent AAP's API fields returned in `Read` requests, that get parsed into the following struct hierarchy.
- `BaseDetailDataSourceModel`, and children `BaseDetailDataSourceModelWithOrg` that will receive the parsed information from incoming requests of the Read operation.
- `BaseDataSource`, and `BaseDataSourceWithOrg`. These incorporate all the required functions of the `datasource.DataSource` interface of the provider SDK. Some functions like `Read` or `ConfigValidators` have been overloaded to support the inheritance trees of with/without AAP organization. Due to Go's static typing, this refactor isn't possible other way without smashing every field together into a single struct as it was before.

With this refactor, this is an example of a DataSource file. 31 lines!
```go
package provider

import (
	"github.com/hashicorp/terraform-plugin-framework/datasource"
)

// JobTemplate AAP API model
type JobTemplateAPIModel struct {
	BaseDetailAPIModelWithOrg
}

// JobTemplateDataSourceModel maps the data source schema data.
type JobTemplateDataSourceModel struct {
	BaseDetailDataSourceModelWithOrg
}

// JobTemplateDataSource is the data source implementation.
type JobTemplateDataSource struct {
	BaseDataSourceWithOrg
}

// NewJobTemplateDataSource is a helper function to simplify the provider implementation.
func NewJobTemplateDataSource() datasource.DataSource {
	return &JobTemplateDataSource{
		BaseDataSourceWithOrg: *NewBaseDataSourceWithOrg(nil, StringDescriptions{
			MetadataEntitySlug:    "job_template",
			DescriptiveEntityName: "JobTemplate",
			ApiEntitySlug:         "job_templates",
		}),
	}
}
```