### PR TITLE
Running code coverage tests within the Sonar Cloud Static Scan action

### DIFF
--- a/.github/workflows/sonar-checks.yml
+++ b/.github/workflows/sonar-checks.yml
@@ -11,14 +11,30 @@ jobs:
   sonarcloud:
     name: Sonar Cloud Static Scans
     runs-on: ubuntu-latest
+    env:
+        go_version: '1.23'
+        
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
 
     steps:
-      - name: Fetch Code Coverage Report
-        uses: actions/download-artifact@v4
+      - name: Checkout Provider
+        uses: actions/checkout@v4
         with:
-          name: coverage-report
-          path: .
+          fetch-depth: 0
+
+      - name: Setup Go ${{ env.go_version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.go_version }}
+
+      - name: Run unit tests with coverage
+        run: make testcov
+
+      # - name: Fetch Code Coverage Report
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: coverage-report
+      #     path: .
 
       - name: Sonar Cloud Scan
         uses: SonarSource/sonarqube-scan-action@v5.2.0

--- a/.github/workflows/unit_test_and_quality.yml
+++ b/.github/workflows/unit_test_and_quality.yml
@@ -30,11 +30,14 @@ jobs:
       - name: Build the Provider
         run: go build -v ./...
 
-      - name: Run unit tests with coverage
-        run: make testcov
+      - name: Run Provider Unit Tests
+        run: make test
 
-      - name: Upload code coverage report from unit tests
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-report
-          path: unit-testing.cov
+      # - name: Run unit tests with coverage
+      #   run: make testcov
+
+      # - name: Upload code coverage report from unit tests
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: coverage-report
+      #     path: unit-testing.cov


### PR DESCRIPTION
Removed the code coverage generation from the main unit testing action, and placed it in the sonar scan action.