### PR TITLE
Remove checks that break Terraform RPC Flow

### DIFF
--- a/internal/provider/general_api_models.go
+++ b/internal/provider/general_api_models.go
@@ -288,17 +288,18 @@ func (d *BaseDataSourceWithOrg) Read(ctx context.Context, req datasource.ReadReq
 
 // Configure adds the provider configured client to the data source.
 func (d *BaseDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	// Check that the current context is active
-	if !IsContextActive("Configure", ctx, resp.Diagnostics) {
-		return
-	}
-
 	// Check that the response and diagnostics pointer is defined
 	if resp == nil {
 		tflog.Error(ctx, "Response not defined, we cannot continue with the execution")
 		return
 	}
 
+	// Check that the current context is active
+	if !IsContextActive("Configure", ctx, resp.Diagnostics) {
+		return
+	}
+
+	// Check that the provider data is configured
 	if req.ProviderData == nil {
 		return
 	}


### PR DESCRIPTION
These checks actually break the flow of Terraform's RPC calls. This is why we were having odd functionality using the base datasource.

The order of the checks are documented here: https://developer.hashicorp.com/terraform/plugin/framework/internals/rpcs#rpcs-and-framework-functionality 