### PR TITLE
aap-49554 Acceptance test to diagnose running workflow jobs with no Inventory ID specified in HCL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,16 @@ The inventory resource test requires the AAP instance to have a second organizat
 ```bash
 export AAP_TEST_ORGANIZATION_ID=<the ID of Non-Default in your AAP instance>
 ```
-Create inventory `49554 Inventory` on Default organization
-Create a Workflow Job Template called `49554 Workflow Job Template`
+Create inventory `Inventory For Workflow"` on Default organization
+Create a Workflow Job Template called `Workflow with Inventory`
   - Assign organization to `Default`
-  - Assign inventory to `49554 Inventory`
+  - Assign `Inventory For Workflow`
   - Make sure `Prompt on launch` **is not checked** for the inventory
   - Make sure `Prompt on launch` **is checked** for `Extra variables`
   - Add a default step and save
 ```bash
-export AAP_49554_JOB_TEMPLATE_ID=<the ID of `49554 Workflow Job Template`>
-export AAP_49554_INVENTORY_ID=<the ID of `49554 Inventory`>
+export AAP_TEST_WORKFLOW_INVENTORY_ID=<the ID of `Workflow with Inventory`>
+export AAP_TEST_INVENTORY_FOR_WF_ID=<the ID of `Inventory For Workflow"`>
 ```
 
 Then you can run acceptance tests with `make testacc`.

--- a/internal/provider/workflow_job_resource_test.go
+++ b/internal/provider/workflow_job_resource_test.go
@@ -281,8 +281,8 @@ func TestAccAAPWorkflowJob_Basic(t *testing.T) {
 }
 
 func TestAccAAPWorkflowJobWithNoInventoryID(t *testing.T) {
-	jobTemplateID := os.Getenv("AAP_49554_JOB_TEMPLATE_ID")
-	inventoryID := os.Getenv("AAP_49554_INVENTORY_ID")
+	jobTemplateID := os.Getenv("AAP_TEST_WORKFLOW_INVENTORY_ID")
+	inventoryID := os.Getenv("AAP_TEST_INVENTORY_FOR_WF_ID")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccWorkflowJobResourcePreCheck(t) },
@@ -369,37 +369,6 @@ func TestAccAAPWorkflowJob_UpdateWithNewInventoryIdPromptOnLaunch(t *testing.T) 
 					resource.TestMatchResourceAttr("aap_workflow_job.test", "status", regexp.MustCompile("^(failed|pending|running|complete|successful|waiting)$")),
 					resource.TestMatchResourceAttr("aap_workflow_job.test", "url", regexp.MustCompile("^/api(/controller)?/v2/workflow_jobs/[0-9]*/$")),
 
-					testAccCheckWorkflowJobUpdate(&jobURLBefore, true),
-					// Wait for the job to finish so the inventory can be deleted
-					testAccCheckWorkflowJobPause(ctx, "aap_workflow_job.test"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAAPWorkflowJob_UpdateWithNewInventoryIdPromptOnLaunch2(t *testing.T) {
-	// In order to run the this test for the workflow job resource, you must have a working job template already in your AAP instance.
-	// The job template used must be set to require an inventory on launch. Export the id of this job template into the
-	// environment variable AAP_TEST_WORKFLOW_JOB_TEMPLATE_ID. Otherwise this test will fail when running the suite.
-
-	var jobURLBefore string
-
-	inventoryName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	jobTemplateID := os.Getenv("AAP_TEST_WORKFLOW_JOB_TEMPLATE_ID")
-	ctx := context.Background()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccWorkflowJobResourcePreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Create and Read testing
-			{
-				Config: testAccUpdateWorkflowJobWithInventoryID(inventoryName, jobTemplateID),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestMatchResourceAttr("aap_workflow_job.test", "status", regexp.MustCompile("^(failed|pending|running|complete|successful|waiting)$")),
-					resource.TestMatchResourceAttr("aap_workflow_job.test", "url", regexp.MustCompile("^/api(/controller)?/v2/workflow_jobs/[0-9]*/$")),
-					resource.TestCheckResourceAttrPair("aap_workflow_job.test", "inventory_id", "aap_inventory.test", "id"),
 					testAccCheckWorkflowJobUpdate(&jobURLBefore, true),
 					// Wait for the job to finish so the inventory can be deleted
 					testAccCheckWorkflowJobPause(ctx, "aap_workflow_job.test"),


### PR DESCRIPTION
### Acceptance Tests for  #111 

Add test validation to ensure an inventory_id provided in a workflow job is not overwritten with default value "1" when job template is run (AAP-49554).

Fix involves  [this line](https://github.com/ansible/terraform-provider-aap/blob/0d39e73f4b366192ccf404e50e24fd5059c28566/internal/provider/workflow_job_resource.go#L228).