### PR TITLE
Fix workflow job using default inventory id

### DIFF
--- a/internal/provider/workflow_job_resource.go
+++ b/internal/provider/workflow_job_resource.go
@@ -221,19 +221,15 @@ func (r WorkflowJobResource) Delete(_ context.Context, _ resource.DeleteRequest,
 // CreateRequestBody creates a JSON encoded request body from the workflow job resource data
 func (r *WorkflowJobResourceModel) CreateRequestBody() ([]byte, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var inventoryID int64
-
-	// Use default inventory if not provided
-	if r.InventoryID.ValueInt64() == 0 {
-		inventoryID = 1
-	} else {
-		inventoryID = r.InventoryID.ValueInt64()
-	}
 
 	// Convert workflow job resource data to API data model
 	workflowJob := WorkflowJobAPIModel{
 		ExtraVars: r.ExtraVars.ValueString(),
-		Inventory: inventoryID,
+	}
+
+	// Set inventory id if provided
+	if r.InventoryID.ValueInt64() != 0 {
+		workflowJob.Inventory = r.InventoryID.ValueInt64()
 	}
 
 	// Create JSON encoded request body

--- a/internal/provider/workflow_job_resource_test.go
+++ b/internal/provider/workflow_job_resource_test.go
@@ -57,7 +57,7 @@ func TestWorkflowJobResourceCreateRequestBody(t *testing.T) {
 				InventoryID: basetypes.NewInt64Unknown(),
 				TemplateID:  types.Int64Value(1),
 			},
-			expected: []byte(`{"inventory":1}`),
+			expected: []byte(`{}`),
 		},
 		{
 			name: "null values",
@@ -66,7 +66,7 @@ func TestWorkflowJobResourceCreateRequestBody(t *testing.T) {
 				InventoryID: basetypes.NewInt64Null(),
 				TemplateID:  types.Int64Value(1),
 			},
-			expected: []byte(`{"inventory":1}`),
+			expected: []byte(`{}`),
 		},
 		{
 			name: "extra vars only",
@@ -74,7 +74,7 @@ func TestWorkflowJobResourceCreateRequestBody(t *testing.T) {
 				ExtraVars:   customtypes.NewAAPCustomStringValue("{\"test_name\":\"extra_vars\", \"provider\":\"aap\"}"),
 				InventoryID: basetypes.NewInt64Null(),
 			},
-			expected: []byte(`{"inventory":1,"extra_vars":"{\"test_name\":\"extra_vars\", \"provider\":\"aap\"}"}`),
+			expected: []byte(`{"extra_vars":"{\"test_name\":\"extra_vars\", \"provider\":\"aap\"}"}`),
 		},
 		{
 			name: "inventory vars only",


### PR DESCRIPTION
Fixes a bug where inventory defaults to 1 when launching a workflow job without specifying an inventory id. Also fixes associated tests that assumed a default inventory id would be used.

Fixes AAP-49554
Fixes #111