### PR TITLE
[RETRY.1] New client functions for retry logic

### DIFF
--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -20,7 +20,9 @@ type ProviderHTTPClient interface {
 	Get(path string) ([]byte, diag.Diagnostics)
 	GetWithStatus(path string) ([]byte, diag.Diagnostics, int)
 	Update(path string, data io.Reader) ([]byte, diag.Diagnostics)
+	UpdateWithStatus(path string, data io.Reader) ([]byte, diag.Diagnostics, int)
 	Delete(path string) ([]byte, diag.Diagnostics)
+	DeleteWithStatus(path string) ([]byte, diag.Diagnostics, int)
 	setApiEndpoint() diag.Diagnostics
 	getApiEndpoint() string
 }
@@ -167,16 +169,37 @@ func (c *AAPClient) Get(path string) ([]byte, diag.Diagnostics) {
 // Update sends a PUT request with the provided data to the provided path, checks for errors,
 // and returns the response body with any errors as diagnostics.
 func (c *AAPClient) Update(path string, data io.Reader) ([]byte, diag.Diagnostics) {
+	body, diags, _ := c.UpdateWithStatus(path, data)
+	return body, diags
+}
+
+// UpdateWithStatus sends a PUT request with the provided data to the provided path, checks for errors,
+// and returns the response body with any errors as diagnostics and the status code.
+func (c *AAPClient) UpdateWithStatus(path string, data io.Reader) ([]byte, diag.Diagnostics, int) {
 	updateResponse, body, err := c.doRequest("PUT", path, data)
 	diags := ValidateResponse(updateResponse, body, err, []int{http.StatusOK})
-	return body, diags
+	if updateResponse == nil {
+		diags.AddError("HTTP response error", "No HTTP response from server")
+		return body, diags, http.StatusInternalServerError
+	}
+	return body, diags, updateResponse.StatusCode
 }
 
 // Delete sends a DELETE request to the provided path, checks for errors, and returns any errors as diagnostics.
 func (c *AAPClient) Delete(path string) ([]byte, diag.Diagnostics) {
+	body, diags, _ := c.DeleteWithStatus(path)
+	return body, diags
+}
+
+// DeleteWithStatus sends a DELETE request to the provided path, checks for errors, and returns any errors as diagnostics and the status code.
+func (c *AAPClient) DeleteWithStatus(path string) ([]byte, diag.Diagnostics, int) {
 	deleteResponse, body, err := c.doRequest("DELETE", path, nil)
 	// Note: the AAP API documentation says that an inventory delete request should return a 204 response, but it currently returns a 202.
 	// Once that bug is fixed we should be able to update this to just expect http.StatusNoContent.
 	diags := ValidateResponse(deleteResponse, body, err, []int{http.StatusAccepted, http.StatusNoContent})
-	return body, diags
+	if deleteResponse == nil {
+		diags.AddError("HTTP response error", "No HTTP response from server")
+		return body, diags, http.StatusInternalServerError
+	}
+	return body, diags, deleteResponse.StatusCode
 }


### PR DESCRIPTION
# New client functions for retry logic

## Overview
Adds foundational client functions `UpdateWithStatus` and `DeleteWithStatus` to support retry logic implementation.

**Jira:** AAP-46309  
**Issue:** #68
**Related:** Split from #100 and #118 for easier review

## Changes
- **`UpdateWithStatus()`** - HTTP PATCH with status code return
- **`DeleteWithStatus()`** - HTTP DELETE with status code return  
- **Unit tests** - Complete test coverage for both functions

## What to Review
- Function signatures and return values
- HTTP status code handling logic
- Error handling and diagnostics
- Unit test coverage and scenarios

## Next Steps
Follow-up PR will implement the actual retry logic using these client functions.

## Breaking Changes
**None** - Additive changes only.