### PR TITLE
Fix issue in IsContextActive

### DIFF
--- a/internal/provider/base_datasource.go
+++ b/internal/provider/base_datasource.go
@@ -188,7 +188,7 @@ func (d *BaseDataSource) ValidateConfig(ctx context.Context, req datasource.Vali
 	}
 
 	// Check that the current context is active
-	if !IsContextActive("ValidateConfig", ctx, resp.Diagnostics) {
+	if !IsContextActive("ValidateConfig", ctx, &resp.Diagnostics) {
 		return
 	}
 
@@ -221,7 +221,7 @@ func (d *BaseDataSourceWithOrg) ValidateConfig(ctx context.Context, req datasour
 	}
 
 	// Check that the current context is active
-	if !IsContextActive("ValidateConfig", ctx, resp.Diagnostics) {
+	if !IsContextActive("ValidateConfig", ctx, &resp.Diagnostics) {
 		return
 	}
 
@@ -279,7 +279,7 @@ func (d *BaseDataSource) Configure(ctx context.Context, req datasource.Configure
 	}
 
 	// Check that the current context is active
-	if !IsContextActive("Configure", ctx, resp.Diagnostics) {
+	if !IsContextActive("Configure", ctx, &resp.Diagnostics) {
 		return
 	}
 

--- a/internal/provider/base_utils.go
+++ b/internal/provider/base_utils.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-func IsContextActive(operationName string, ctx context.Context, diagnostics diag.Diagnostics) bool {
-	if ctx.Err() == nil {
+func IsContextActive(operationName string, ctx context.Context, diagnostics *diag.Diagnostics) bool {
+	if ctx.Err() != nil {
 		if diagnostics != nil {
 			diagnostics.AddError(
 				fmt.Sprintf("Aborting %s operation", operationName),
@@ -31,7 +31,7 @@ func DoReadPreconditionsMeet(ctx context.Context, resp *datasource.ReadResponse,
 	}
 
 	// Check that the current context is active
-	if !IsContextActive("Read", ctx, resp.Diagnostics) {
+	if !IsContextActive("Read", ctx, &resp.Diagnostics) {
 		return false
 	}
 

--- a/internal/provider/base_utils_test.go
+++ b/internal/provider/base_utils_test.go
@@ -1,0 +1,57 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+func TestIsContextActive(t *testing.T) {
+	var testTable = []struct {
+		testName            string
+		shouldCancelContext bool
+		diagsShouldHaveErr  bool
+		expectedReturnValue bool
+	}{
+		{
+			testName:            "context active",
+			shouldCancelContext: false,
+			diagsShouldHaveErr:  false,
+			expectedReturnValue: true,
+		},
+		{
+			testName:            "context complete",
+			shouldCancelContext: true,
+			diagsShouldHaveErr:  true,
+			expectedReturnValue: false,
+		},
+	}
+
+	for _, test := range testTable {
+		t.Run("test_"+test.testName, func(t *testing.T) {
+			var diags = diag.Diagnostics{}
+			ctx, cancel := context.WithCancel(context.TODO())
+			defer cancel()
+
+			if test.shouldCancelContext {
+				cancel()
+			}
+
+			returnValue := IsContextActive(test.testName, ctx, &diags)
+
+			if returnValue != test.expectedReturnValue {
+				t.Errorf("Got an unexpected return value. got: %t, expected: %t", returnValue, test.expectedReturnValue)
+				return
+			}
+
+			if test.diagsShouldHaveErr {
+				// TODO Why doesn't HasError return true when there is a
+				// diag.ErrorDiagnostic in the list?
+				if !diags.HasError() {
+					t.Errorf("Expected error but received none.")
+				}
+			}
+		})
+	}
+}

--- a/internal/provider/base_utils_test.go
+++ b/internal/provider/base_utils_test.go
@@ -46,8 +46,6 @@ func TestIsContextActive(t *testing.T) {
 			}
 
 			if test.diagsShouldHaveErr {
-				// TODO Why doesn't HasError return true when there is a
-				// diag.ErrorDiagnostic in the list?
 				if !diags.HasError() {
 					t.Errorf("Expected error but received none.")
 				}

--- a/internal/provider/organization_data_source.go
+++ b/internal/provider/organization_data_source.go
@@ -62,7 +62,7 @@ func (d *OrganizationDataSource) ValidateConfig(ctx context.Context, req datasou
 	}
 
 	// Check that the current context is active
-	if !IsContextActive("ValidateConfig", ctx, resp.Diagnostics) {
+	if !IsContextActive("ValidateConfig", ctx, &resp.Diagnostics) {
 		return
 	}
 


### PR DESCRIPTION
Fixes an issue where checking if the current context is active would return the correct status while also writing erroneous error messages. This change also adds unit tests for the `IsContextActive` function and changes the function to pass the `diags` parameter by pointer.