### PR TITLE
[TRIVIAL] Fix aap_job using default inventory id

### DIFF
--- a/changelogs/fragments/20250730-fix-job-inventory-id.yml
+++ b/changelogs/fragments/20250730-fix-job-inventory-id.yml
@@ -1,3 +1,3 @@
 ---
-- bugfixes:
-    - Fix aab_job using default inventory id
+bugfixes:
+  - Fix aab_job using default inventory id

--- a/changelogs/fragments/20250730-fix-job-inventory-id.yml
+++ b/changelogs/fragments/20250730-fix-job-inventory-id.yml
@@ -1,0 +1,3 @@
+---
+- bugfixes:
+    - Fix aab_job using default inventory id

--- a/internal/provider/job_resource.go
+++ b/internal/provider/job_resource.go
@@ -325,9 +325,7 @@ func (r *JobResourceModel) CreateRequestBody() ([]byte, diag.Diagnostics) {
 	var inventoryID int64
 
 	// Use default inventory if not provided
-	if r.InventoryID.ValueInt64() == 0 {
-		inventoryID = 1
-	} else {
+	if r.InventoryID.ValueInt64() != 0 {
 		inventoryID = r.InventoryID.ValueInt64()
 	}
 

--- a/internal/provider/job_resource_test.go
+++ b/internal/provider/job_resource_test.go
@@ -83,7 +83,7 @@ func TestJobResourceCreateRequestBody(t *testing.T) {
 				InventoryID: basetypes.NewInt64Unknown(),
 				TemplateID:  types.Int64Value(1),
 			},
-			expected: []byte(`{"inventory":1}`),
+			expected: []byte(`{}`),
 		},
 		{
 			name: "null values",
@@ -92,7 +92,7 @@ func TestJobResourceCreateRequestBody(t *testing.T) {
 				InventoryID: basetypes.NewInt64Null(),
 				TemplateID:  types.Int64Value(1),
 			},
-			expected: []byte(`{"inventory":1}`),
+			expected: []byte(`{}`),
 		},
 		{
 			name: "extra vars only",
@@ -100,7 +100,7 @@ func TestJobResourceCreateRequestBody(t *testing.T) {
 				ExtraVars:   customtypes.NewAAPCustomStringValue("{\"test_name\":\"extra_vars\", \"provider\":\"aap\"}"),
 				InventoryID: basetypes.NewInt64Null(),
 			},
-			expected: []byte(`{"inventory":1,"extra_vars":"{\"test_name\":\"extra_vars\", \"provider\":\"aap\"}"}`),
+			expected: []byte(`{"extra_vars":"{\"test_name\":\"extra_vars\", \"provider\":\"aap\"}"}`),
 		},
 		{
 			name: "inventory vars only",


### PR DESCRIPTION
Prevents the aap_job resource from using the a default inventory-id of 1.

Fixes AAP-49876