### PR TITLE
[TRIVIAL] Pin Golang version for Terraform doc generation job

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -9,21 +9,28 @@ on:
 jobs:
   generate-docs:
     runs-on: ubuntu-latest
+    env:
+        go_version: '1.23.9'
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - name: Checkout Provider
+        uses: actions/checkout@v4
         with:
-          go-version: '1.23'
+          fetch-depth: 0
 
-      - name: Install dependencies
+      - name: Setup Go ${{ env.go_version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.go_version }}
+
+      - name: Install Go dependencies
         run: go get .
+
+      - name: Build the Provider
+        run: go build -v ./...
 
       - name: Install tfplugindocs
         run: go get github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest
-
-      - name: Build
-        run: go build -v ./...
 
       - uses: hashicorp/setup-terraform@v3
         with:


### PR DESCRIPTION
I'm seeing an error about not finding the correct dependencies in Golang 1.23.11 in the documentation generation job. This works locally on Golang 1.23.9 for me.

See failures:
https://github.com/ansible/terraform-provider-aap/actions/runs/16759641541