### PR TITLE
[TRIVIAL] [AAP-47221] 3 - Failing acceptance test (To be fixed by PR 1 & 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,19 +84,21 @@ export AAP_TEST_WORKFLOW_INVENTORY_ID=<the ID of `Workflow with Inventory`>
 export AAP_TEST_INVENTORY_FOR_WF_ID=<the ID of `Inventory For Workflow`>
 ```
 
-The Host resource test requires the AAP instance to have a Job Template that sleeps for a handful of seconds. We recommend this job sleeps for 15 seconds.
+The Host resource test requires the AAP instance to have a Job Template that sleeps for a handful of seconds. 
+We recommend using the `sleep.yml` playbook from the [ansible/test-playbooks](https://github.com/ansible/test-playbooks) 
+repository, configured to sleep for 15 seconds.
 
 Export the IDs of this job template:
 
-```
-export AAP_TEST_JOB_FOR_HOST_RETRY_ID=<the ID of a job template that sleeps for 15 seconds>
+```bash
+export AAP_TEST_JOB_FOR_HOST_RETRY_ID=<the ID of a job template using sleep.yml that sleeps for 15 seconds>
 ```
 
 AAP 2.4 version note - If you are running the tests against an AAP 2.4 version instance, set the description for Default Organization to `The default organization for Ansible Automation Platform`
 
 Then you can run acceptance tests with `make testacc`.
 
-**WARNING**: running acceptance tests for the job resource will launch several jobs for the specified job template. It's strongly recommended that you create a "check" type job template for testing to ensure the launched jobs do not deploy any actual infrastructure.
+**WARNING**: running acceptance tests for the job resource will launch several jobs for the specified job template. Strongly recommended that you create a "check" type job template for testing to ensure the launched jobs do not deploy any actual infrastructure.
 
 ## Examples
 

--- a/internal/provider/job_resource_test.go
+++ b/internal/provider/job_resource_test.go
@@ -27,6 +27,7 @@ import (
 
 const (
 	statusRunningConst = "running"
+	statusPendingConst = "pending"
 )
 
 func TestJobResourceSchema(t *testing.T) {
@@ -433,7 +434,7 @@ func TestAccAAPJob_WaitForCompletion(t *testing.T) {
 					// This check should FAIL on main branch due to AAP-47221 bug
 					// The job status should be "successful" or "failed", not "pending"
 					resource.TestCheckResourceAttrWith("aap_job.test", "status", func(value string) error {
-						if value == "pending" {
+						if value == statusPendingConst {
 							return fmt.Errorf("AAP-47221 bug: job status is 'pending' instead of final state")
 						}
 						if !IsFinalStateAAPJob(value) {
@@ -598,7 +599,7 @@ func TestRetryUntilAAPJobReachesAnyFinalState_ErrorHandling(t *testing.T) {
 		}
 
 		// Verify initial state
-		if model.Status.ValueString() != "pending" {
+		if model.Status.ValueString() != statusPendingConst {
 			t.Errorf("expected initial status 'pending', got '%s'", model.Status.ValueString())
 		}
 
@@ -617,7 +618,7 @@ func TestRetryUntilAAPJobReachesAnyFinalState_ErrorHandling(t *testing.T) {
 		}
 
 		// Model state should remain unchanged since parsing never succeeded
-		if model.Status.ValueString() != "pending" {
+		if model.Status.ValueString() != statusPendingConst {
 			t.Errorf("expected status to remain 'pending' after error, got '%s'", model.Status.ValueString())
 		}
 	})

--- a/internal/provider/job_resource_test.go
+++ b/internal/provider/job_resource_test.go
@@ -419,7 +419,7 @@ func TestAccAAPJob_UpdateWithTrigger(t *testing.T) {
 // when wait_for_completion=true. This test demonstrates the bug described in AAP-47221.
 // Expected to FAIL on main branch, PASS after PR #131 and #132 are merged.
 func TestAccAAPJob_WaitForCompletion(t *testing.T) {
-	jobTemplateID := os.Getenv("AAP_TEST_JOB_TEMPLATE_ID")
+	jobTemplateID := os.Getenv("AAP_TEST_JOB_FOR_HOST_RETRY_ID")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccJobResourcePreCheck(t) },

--- a/internal/provider/job_resource_test.go
+++ b/internal/provider/job_resource_test.go
@@ -418,7 +418,7 @@ func TestAccAAPJob_UpdateWithTrigger(t *testing.T) {
 }
 
 // TestAccAAPJob_WaitForCompletion tests that job status is correctly updated to final state
-// when wait_for_completion=true. This test demonstrates the bug described in AAP-47221.
+// when wait_for_completion=true. This test demonstrates the bug described in Issue #78
 // Expected to FAIL on main branch, PASS after PR #131 and #132 are merged.
 func TestAccAAPJob_WaitForCompletion(t *testing.T) {
 	jobTemplateID := os.Getenv("AAP_TEST_JOB_FOR_HOST_RETRY_ID")
@@ -431,11 +431,11 @@ func TestAccAAPJob_WaitForCompletion(t *testing.T) {
 				Config: testAccJobWithWaitForCompletion(jobTemplateID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobExists,
-					// This check should FAIL on main branch due to AAP-47221 bug
+					// This check should FAIL on main branch due to issue #78
 					// The job status should be "successful" or "failed", not "pending"
 					resource.TestCheckResourceAttrWith("aap_job.test", "status", func(value string) error {
 						if value == statusPendingConst {
-							return fmt.Errorf("AAP-47221 bug: job status is 'pending' instead of final state")
+							return fmt.Errorf("issue #78 bug: job status is still in 'pending' instead of final state")
 						}
 						if !IsFinalStateAAPJob(value) {
 							return fmt.Errorf("job status '%s' is not a final state", value)

--- a/internal/provider/job_resource_test.go
+++ b/internal/provider/job_resource_test.go
@@ -295,6 +295,7 @@ func testAccJobResourcePreCheck(t *testing.T) {
 
 	requiredAAPJobEnvVars := []string{
 		"AAP_TEST_JOB_TEMPLATE_ID",
+		"AAP_TEST_JOB_FOR_HOST_RETRY_ID",
 	}
 
 	for _, key := range requiredAAPJobEnvVars {


### PR DESCRIPTION
### Summary [AAP-47221] - Issue #78
Adds acceptance test that demonstrates the job status bug where wait_for_completion=true jobs get stuck in pending status instead of updating to final states.
Test behavior:

1.  PASSES with PR #131 applied (job reaches final state)
2.  FAILS without fixes (job stuck in pending, times out)

Changes:

- New TestAccAAPJob_WaitForCompletion test with custom validation
- Uses sleepy job template via AAP_TEST_JOB_FOR_HOST_RETRY_ID environment variable
- Validates any final state (successful, failed, error, canceled) instead of hardcoding one status

Dependencies:

1. Requires PR #131 (diagnostics error handling)
2. Requires PR #132 (logging fixes)