### PR TITLE
Update sonar-scan-action due to security vulnerability

### DIFF
--- a/.github/workflows/sonar-checks.yml
+++ b/.github/workflows/sonar-checks.yml
@@ -63,7 +63,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: SonarCube Scan
-        uses: SonarSource/sonarqube-scan-action@v5.2.0
+        uses: SonarSource/sonarqube-scan-action@v5
         env:
           SONAR_TOKEN: ${{ secrets[format('{0}', vars.SONAR_TOKEN_SECRET_NAME)] }}
         with:

--- a/.github/workflows/unit_test_and_quality.yml
+++ b/.github/workflows/unit_test_and_quality.yml
@@ -34,7 +34,7 @@ jobs:
         run: make testcov
 
       - name: SonarCube Static Scans (on push)
-        uses: SonarSource/sonarqube-scan-action@v5.2.0
+        uses: SonarSource/sonarqube-scan-action@v5
         if: github.event_name == 'push' && startsWith(github.repository, 'ansible') && endsWith(github.repository, '/terraform-provider-aap')
         env:
           SONAR_TOKEN: ${{ secrets[format('{0}', vars.SONAR_TOKEN_SECRET_NAME)] }}


### PR DESCRIPTION
Previously requesting v5.2.0. https://community.sonarsource.com/t/security-advisory-sonarqube-scanner-github-action/147696 reports a fix in v5.3.1 and just using v5 (or master) was suggested.