### PR TITLE
[AAP-46311] 1: Authenticators for basic and token auth

### DIFF
--- a/internal/provider/client_authenticators.go
+++ b/internal/provider/client_authenticators.go
@@ -1,0 +1,73 @@
+package provider
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+type AAPClientAuthenticator interface {
+	Configure(*http.Request)
+}
+
+// Basic authenticator supports username/password auth
+type AAPClientBasicAuthenticator struct {
+	username string
+	password string
+}
+
+func NewBasicAuthenticator(username *string, password *string) (*AAPClientBasicAuthenticator, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if username == nil {
+		diags.AddError(
+			"Missing username",
+			"Unable to create a basic authenticator without username")
+	}
+	if password == nil {
+		diags.AddError(
+			"Missing password",
+			"Unable to create a basic authenticator without password")
+	}
+	if diags.HasError() {
+		return nil, diags
+	}
+	return &AAPClientBasicAuthenticator{
+		username: *username,
+		password: *password,
+	}, nil
+}
+
+func (a *AAPClientBasicAuthenticator) Configure(req *http.Request) {
+	// To configure basic auth, we can just use http.Request's SetBasicAuth
+	req.SetBasicAuth(a.username, a.password)
+}
+
+// Token authenticator supports Token auth
+type AAPClientTokenAuthenticator struct {
+	token string // Required
+}
+
+func NewTokenAuthenticator(token *string) (*AAPClientTokenAuthenticator, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if token == nil {
+		// token must be supplied. If not, that's an error
+		diags.AddError(
+			"Missing token",
+			"Unable to create a token authenticator without token")
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return &AAPClientTokenAuthenticator{
+		token: *token,
+	}, nil
+}
+
+func (a *AAPClientTokenAuthenticator) Configure(req *http.Request) {
+	header := "Authorization"
+	prefix := "Bearer"
+	req.Header.Set(header, fmt.Sprintf("%s %s", prefix, a.token))
+}

--- a/internal/provider/client_authenticators_test.go
+++ b/internal/provider/client_authenticators_test.go
@@ -1,0 +1,135 @@
+package provider
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestNewBasicAuthenticator(t *testing.T) {
+	testUsername := "testusername"
+	testPassword := "testpassword"
+	var testTable = []struct {
+		name          string
+		username      *string
+		password      *string
+		expectSuccess bool
+	}{
+		{
+			name:          "Success when providing username and password",
+			username:      &testUsername,
+			password:      &testPassword,
+			expectSuccess: true,
+		},
+		{
+			name:          "Failure when username and password are nil",
+			username:      nil,
+			password:      nil,
+			expectSuccess: false,
+		},
+		{
+			name:          "Failure when username is provided and password is nil",
+			username:      &testUsername,
+			password:      nil,
+			expectSuccess: false,
+		},
+		{
+			name:          "Failure with when username is nil and password is provided",
+			username:      nil,
+			password:      &testPassword,
+			expectSuccess: false,
+		},
+	}
+	for _, test := range testTable {
+		t.Run(test.name, func(t *testing.T) {
+			auth, diags := NewBasicAuthenticator(test.username, test.password)
+			if test.expectSuccess {
+				if auth == nil {
+					t.Errorf("Expected NewBasicAuthenticator result to be defined, failed with %v", diags)
+				}
+			} else {
+				if !diags.HasError() {
+					t.Errorf("Expected NewBasicAuthenticator to fail, received %v", auth)
+				}
+			}
+		})
+	}
+}
+
+func TestBasicAuthenticatorConfigure(t *testing.T) {
+	testUsername := "username"
+	testPassword := "password"
+	auth, _ := NewBasicAuthenticator(&testUsername, &testPassword)
+	req, _ := http.NewRequest("", "", strings.NewReader(""))
+	auth.Configure(req)
+	actual := req.Header["Authorization"][0]
+	expected := "Basic dXNlcm5hbWU6cGFzc3dvcmQ=" // base64 encoding of string "username:password"
+	if actual != expected {
+		t.Errorf("Expected (%s) not equal to actual (%s)", expected, actual)
+	}
+}
+
+func TestNewTokenAuthenticator(t *testing.T) {
+	testToken := "testtoken"
+	var testTable = []struct {
+		name          string
+		token         *string
+		expectSuccess bool
+	}{
+		{
+			name:          "Success when token is provided",
+			token:         &testToken,
+			expectSuccess: true,
+		},
+		{
+			name:          "Failure when token is nil ",
+			token:         nil,
+			expectSuccess: false,
+		},
+	}
+	for _, test := range testTable {
+		t.Run(test.name, func(t *testing.T) {
+			auth, diags := NewTokenAuthenticator(test.token)
+			if test.expectSuccess {
+				if auth == nil {
+					t.Errorf("Expected NewTokenAuthenticator result to be defined, failed with %v", diags)
+				}
+			} else {
+				if !diags.HasError() {
+					t.Errorf("Expected NewTokenAuthenticator to fail, received %v", auth)
+				}
+			}
+		})
+	}
+}
+
+func TestTokenAuthenticatorConfigure(t *testing.T) {
+	testToken := "testtoken"
+
+	var testTable = []struct {
+		name         string
+		token        *string
+		expectHeader string
+		expectValue  string
+	}{
+		{
+			name:         "Configure defaults header to Authorization: Bearer ...",
+			token:        &testToken,
+			expectHeader: "Authorization",
+			expectValue:  "Bearer testtoken",
+		},
+	}
+
+	for _, test := range testTable {
+		t.Run(test.name, func(t *testing.T) {
+			auth, _ := NewTokenAuthenticator(test.token)
+			req, _ := http.NewRequest("", "", strings.NewReader(""))
+			auth.Configure(req)
+			actual := req.Header[test.expectHeader][0]
+			expected := test.expectValue
+			if actual != expected {
+				t.Errorf("Expected (%s) not equal to actual (%s)", expected, actual)
+			}
+		})
+	}
+}

--- a/internal/provider/client_authenticators_test.go
+++ b/internal/provider/client_authenticators_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -60,7 +61,7 @@ func TestBasicAuthenticatorConfigure(t *testing.T) {
 	testUsername := "username"
 	testPassword := "password"
 	auth, _ := NewBasicAuthenticator(&testUsername, &testPassword)
-	req, _ := http.NewRequest("", "", strings.NewReader(""))
+	req, _ := http.NewRequestWithContext(context.TODO(), http.MethodGet, "", strings.NewReader(""))
 	auth.Configure(req)
 	actual := req.Header["Authorization"][0]
 	expected := "Basic dXNlcm5hbWU6cGFzc3dvcmQ=" // base64 encoding of string "username:password"

--- a/internal/provider/client_authenticators_test.go
+++ b/internal/provider/client_authenticators_test.go
@@ -124,7 +124,7 @@ func TestTokenAuthenticatorConfigure(t *testing.T) {
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
 			auth, _ := NewTokenAuthenticator(test.token)
-			req, _ := http.NewRequest("", "", strings.NewReader(""))
+			req, _ := http.NewRequestWithContext(context.TODO(), http.MethodGet, "", strings.NewReader(""))
 			auth.Configure(req)
 			actual := req.Header[test.expectHeader][0]
 			expected := test.expectValue


### PR DESCRIPTION
This is new code in new files and is not yet integrated into the provider, so it can be reviewed in isolation.

- Creates interface `AAPClientAuthenticator` with `Configure` method that authenticates an HTTP request
- Creates two authenticators: `AAPClientBasicAuthenticator` (username+password) and `AAPClientTokenAuthenticator` (token) that satisfy this interface
- Includes unit tests to cover behavior

Part 1 of https://issues.redhat.com/browse/AAP-46311