### PR TITLE
[AAP-46311] 2: Playbook update to generate token

### DIFF
--- a/testing/playbook.yml
+++ b/testing/playbook.yml
@@ -70,8 +70,7 @@
         playbook: "sleep.yml"
         inventory: "Demo Inventory"
       register: job_template_sleep
-    # To authenticate with a Token, generate one with ansible.controller.token,
-    # which creates a Personal Access Token that supports 2.4+ for controller access.
+    # Generate a token to support provider's token authentication
     - name: Create a token for provider to use for testing
       block:
       # Attempt to create platform.token first (2.5+), with fallback to controller.token

--- a/testing/playbook.yml
+++ b/testing/playbook.yml
@@ -70,6 +70,31 @@
         playbook: "sleep.yml"
         inventory: "Demo Inventory"
       register: job_template_sleep
+    # To authenticate with a Token, generate one with ansible.controller.token,
+    # which creates a Personal Access Token that supports 2.4+ for controller access.
+    - name: Create a token for provider to use for testing
+      block:
+      # Attempt to create platform.token first (2.5+), with fallback to controller.token
+      - name: Create a platform token for token authentication
+        ansible.platform.token:
+          description: "Testing terraform-provider-aap"
+          scope: write
+        register: platform_token
+      - name: Store platform token
+        ansible.builtin.set_fact:
+          token_type: platform
+          token: "{{ platform_token.ansible_facts.aap_token.token }}"
+      rescue:
+      # Creating a platform token failed, fall back to controller.token for 2.4 compatibility
+      - name: Create a token for token authentication
+        ansible.controller.token:
+          description: "Testing terraform-provider-aap"
+          scope: write
+        register: controller_token
+      - name: Store platform token
+        ansible.builtin.set_fact:
+          token_type: controller
+          token: "{{ controller_token.ansible_facts.controller_token.token }}"
     # The provider acceptance tests are configured to read the IDs of all of these
     # test resources from the environment, so we write a local .env file that exports
     # all of them

--- a/testing/requirements.yml
+++ b/testing/requirements.yml
@@ -1,3 +1,5 @@
 collections:
   # https://console.redhat.com/ansible/automation-hub/repo/published/ansible/controller/docs/
   - name: ansible.controller
+  # https://console.redhat.com/ansible/automation-hub/repo/published/ansible/platform/docs/
+  - name: ansible.platform

--- a/testing/templates/acceptance_test_vars.env.j2
+++ b/testing/templates/acceptance_test_vars.env.j2
@@ -5,3 +5,6 @@ export AAP_TEST_ORGANIZATION_ID="{{ organization_non_default.id }}"
 export AAP_TEST_WORKFLOW_INVENTORY_ID="{{ workflow_with_inventory.id }}"
 export AAP_TEST_INVENTORY_FOR_WF_ID="{{ inventory_for_workflow.id }}"
 export AAP_TEST_JOB_FOR_HOST_RETRY_ID="{{ job_template_sleep.id }}"
+
+# {{ token_type }} token
+export AAP_TOKEN="{{ token }}"


### PR DESCRIPTION
This change only modifies the playbook introduced in #138 to support testing, so it can be reviewed in isolation.

- Updates playbook to create a token, preferring a platform (gateway) token but falling back to controller token on 2.4
- Updates template to output token in local env file to support acceptance testing
- Adds ansible.platform collection to requirements.yml since this collection provides the platform token module

Part 2 of https://issues.redhat.com/browse/AAP-46311