### PR TITLE
[AAP-46311] 3: Support token authentication

### DIFF
--- a/changelogs/fragments/20250916-support-token-authentication.yml
+++ b/changelogs/fragments/20250916-support-token-authentication.yml
@@ -1,0 +1,2 @@
+major_changes:
+  - Adds support for Token authentication via the AAP_TOKEN environment variable or 'token' attribute in the provider block.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,13 +9,12 @@ description: |-
 The Red Hat Ansible Automation Platform (AAP) provider allows Terraform to reference and manage
 a subset of AAP resources.
 
-
 ## Example Usage
 
 ```terraform
 # This example creates an inventory named `My new inventory`
 # and adds a host `tf_host` and a group `tf_group` to it,
-# and then launches a job based on the "Demo Job Template" 
+# and then launches a job based on the "Demo Job Template"
 # in the "Default" organization using the inventory created.
 #
 terraform {
@@ -27,9 +26,14 @@ terraform {
 }
 
 provider "aap" {
-  host     = "https://AAP_HOST"
-  username = "ansible"
-  password = "test123!"
+  host = "https://AAP_HOST" # Also supports AAP_HOSTNAME environment variable
+
+  # Token authentication is recommended
+  token = "my-aap-token" # Also supports AAP_TOKEN environment variable
+
+  # Basic authentication is also supported, ignored if token is set
+  username = "my-aap-username" # Also supports AAP_USERNAME environment variable
+  password = "my-aap-password" # Also supports AAP_PASSWORD environment variable
 }
 
 resource "aap_inventory" "my_inventory" {
@@ -86,13 +90,22 @@ resource "aap_job" "my_job" {
 
 ### Optional
 
-- `host` (String)
-- `insecure_skip_verify` (Boolean)
-- `password` (String, Sensitive)
-- `timeout` (Number) Timeout specifies a time limit for requests made to the AAP server.Defaults to 5 if not provided. A Timeout of zero means no timeout.
-- `username` (String)
+- `host` (String) AAP Server URL. Can also be configured using the `AAP_HOSTNAME` environment variable.
+- `insecure_skip_verify` (Boolean) If true, configures the provider to skip TLS certificate verification. Can also be configured by setting the `AAP_INSECURE_SKIP_VERIFY` environment variable.
+- `password` (String, Sensitive) Password to use for basic authentication. Ignored if token is set. Can also be configured by setting the `AAP_PASSWORD` environment variable.
+- `timeout` (Number) Timeout specifies a time limit for requests made to the AAP server. Defaults to 5 if not provided. A Timeout of zero means no timeout. Can also be configured by setting the `AAP_TIMEOUT` environment variable
+- `token` (String, Sensitive) Token to use for token authentication. Can also be configured by setting the `AAP_TOKEN` environment variable.
+- `username` (String) Username to use for basic authentication. Ignored if token is set. Can also be configured by setting the `AAP_USERNAME` environment variable.
 
-## Supported Platform
+## Authentication Methods
+
+The provider supports multiple authentication methods with Red Hat Ansible Automation Platform (AAP). Token Authentication is the recommend method, since users can manage tokens for specific integrations (e.g. Terraform), limit token access, and have full control over token lifecycle.
+
+For more information on creating tokens, see [Red Hat Ansible Automation Platform 2.5 - Access management and Authentication](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/access_management_and_authentication/gw-token-based-authentication#proc-controller-apps-create-tokens) for AAP 2.5+ or [Red Hat Ansible Automation Platform 2.4 - Managing Users in automation controller](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/automation_controller_user_guide/assembly-controller-users#proc-controller-user-tokens) for AAP 2.4.
+
+The provider also supports basic authentication with a username and password. If a token is configured, username and password will be ignored.
+
+## Supported Platforms
 
 - Linux AMD64 and ARM64
 - macOS AMD64 and ARM64

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,6 +1,6 @@
 # This example creates an inventory named `My new inventory`
 # and adds a host `tf_host` and a group `tf_group` to it,
-# and then launches a job based on the "Demo Job Template" 
+# and then launches a job based on the "Demo Job Template"
 # in the "Default" organization using the inventory created.
 #
 terraform {
@@ -12,9 +12,14 @@ terraform {
 }
 
 provider "aap" {
-  host     = "https://AAP_HOST"
-  username = "ansible"
-  password = "test123!"
+  host = "https://AAP_HOST" # Also supports AAP_HOSTNAME environment variable
+
+  # Token authentication is recommended
+  token = "my-aap-token" # Also supports AAP_TOKEN environment variable
+
+  # Basic authentication is also supported, ignored if token is set
+  username = "my-aap-username" # Also supports AAP_USERNAME environment variable
+  password = "my-aap-password" # Also supports AAP_PASSWORD environment variable
 }
 
 resource "aap_inventory" "my_inventory" {

--- a/internal/provider/client_test.go
+++ b/internal/provider/client_test.go
@@ -10,6 +10,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type MockAuthenticator struct {
+}
+
+func (m *MockAuthenticator) Configure(req *http.Request) {
+	// Do nothing
+}
+
 func TestComputeURLPath(t *testing.T) {
 	testTable := []struct {
 		name string
@@ -25,11 +32,10 @@ func TestComputeURLPath(t *testing.T) {
 	for _, tc := range testTable {
 		t.Run(tc.name, func(t *testing.T) {
 			client := AAPClient{
-				HostURL:     tc.url,
-				Username:    nil,
-				Password:    nil,
-				httpClient:  nil,
-				ApiEndpoint: "",
+				HostURL:       tc.url,
+				Authenticator: &MockAuthenticator{},
+				httpClient:    nil,
+				ApiEndpoint:   "",
 			}
 			result := client.computeURLPath(tc.path)
 			assert.Equal(t, expected, result, fmt.Sprintf("expected (%s), got (%s)", expected, result))
@@ -71,7 +77,7 @@ func TestReadApiEndpoint(t *testing.T) {
 	}
 	for _, tc := range testTable {
 		t.Run(tc.Name, func(t *testing.T) {
-			client, diags := NewClient(tc.URL, nil, nil, true, 0) // readApiEndpoint() is called when creating client
+			client, diags := NewClient(tc.URL, &MockAuthenticator{}, true, 0) // readApiEndpoint() is called when creating client
 			assert.Equal(t, false, diags.HasError(), fmt.Sprintf("readApiEndpoint() returns errors (%v)", diags))
 			assert.Equal(t, tc.expected, client.getApiEndpoint())
 		})
@@ -127,11 +133,10 @@ func TestUpdateWithStatus(t *testing.T) {
 			defer server.Close()
 
 			client := AAPClient{
-				HostURL:     server.URL,
-				Username:    nil,
-				Password:    nil,
-				httpClient:  &http.Client{},
-				ApiEndpoint: "",
+				HostURL:       server.URL,
+				Authenticator: &MockAuthenticator{},
+				httpClient:    &http.Client{},
+				ApiEndpoint:   "",
 			}
 
 			requestData := bytes.NewReader([]byte(`{"name": "test"}`))
@@ -204,11 +209,10 @@ func TestDeleteWithStatus(t *testing.T) {
 			defer server.Close()
 
 			client := AAPClient{
-				HostURL:     server.URL,
-				Username:    nil,
-				Password:    nil,
-				httpClient:  &http.Client{},
-				ApiEndpoint: "",
+				HostURL:       server.URL,
+				Authenticator: &MockAuthenticator{},
+				httpClient:    &http.Client{},
+				ApiEndpoint:   "",
 			}
 
 			body, diags, statusCode := client.DeleteWithStatus("/test")
@@ -234,11 +238,10 @@ func TestUpdateReusesUpdateWithStatus(t *testing.T) {
 	defer server.Close()
 
 	client := AAPClient{
-		HostURL:     server.URL,
-		Username:    nil,
-		Password:    nil,
-		httpClient:  &http.Client{},
-		ApiEndpoint: "",
+		HostURL:       server.URL,
+		Authenticator: &MockAuthenticator{},
+		httpClient:    &http.Client{},
+		ApiEndpoint:   "",
 	}
 
 	requestData := bytes.NewReader([]byte(`{"name": "test"}`))
@@ -257,11 +260,10 @@ func TestDeleteReusesDeleteWithStatus(t *testing.T) {
 	defer server.Close()
 
 	client := AAPClient{
-		HostURL:     server.URL,
-		Username:    nil,
-		Password:    nil,
-		httpClient:  &http.Client{},
-		ApiEndpoint: "",
+		HostURL:       server.URL,
+		Authenticator: &MockAuthenticator{},
+		httpClient:    &http.Client{},
+		ApiEndpoint:   "",
 	}
 
 	body, diags := client.Delete("/test")

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
@@ -47,30 +48,39 @@ func (p *aapProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"host": schema.StringAttribute{
-				Optional: true,
+				Optional:            true,
+				MarkdownDescription: "AAP Server URL. Can also be configured using the `AAP_HOSTNAME` environment variable.",
 			},
 			"username": schema.StringAttribute{
-				Optional: true,
+				Optional:            true,
+				MarkdownDescription: "Username to use for basic authentication. Ignored if token is set. Can also be configured by setting the `AAP_USERNAME` environment variable.",
 			},
 			"password": schema.StringAttribute{
-				Optional:  true,
-				Sensitive: true,
+				Optional:            true,
+				Sensitive:           true,
+				MarkdownDescription: "Password to use for basic authentication. Ignored if token is set. Can also be configured by setting the `AAP_PASSWORD` environment variable.",
+			},
+			"token": schema.StringAttribute{
+				Optional:            true,
+				Sensitive:           true,
+				MarkdownDescription: "Token to use for token authentication. Can also be configured by setting the `AAP_TOKEN` environment variable.",
 			},
 			"insecure_skip_verify": schema.BoolAttribute{
-				Optional: true,
+				Optional:            true,
+				MarkdownDescription: "If true, configures the provider to skip TLS certificate verification. Can also be configured by setting the `AAP_INSECURE_SKIP_VERIFY` environment variable.",
 			},
 			"timeout": schema.Int64Attribute{
 				Optional: true,
-				Description: "Timeout specifies a time limit for requests made to the AAP server." +
-					"Defaults to 5 if not provided. A Timeout of zero means no timeout.",
+				MarkdownDescription: "Timeout specifies a time limit for requests made to the AAP server. " +
+					"Defaults to 5 if not provided. A Timeout of zero means no timeout. Can also be configured by setting the `AAP_TIMEOUT` environment variable",
 			},
 		},
 	}
 }
 
-func AddConfigurationAttributeError(resp *provider.ConfigureResponse, name, envName string, isUnknown bool) {
+func AddConfigurationAttributeError(diags *diag.Diagnostics, name, envName string, isUnknown bool) {
 	if isUnknown {
-		resp.Diagnostics.AddAttributeError(
+		diags.AddAttributeError(
 			path.Root(name),
 			"Unknown AAP API "+name,
 			fmt.Sprintf("The provider cannot create the AAP API client as there is an unknown configuration value for the AAP API %s. "+
@@ -78,7 +88,7 @@ func AddConfigurationAttributeError(resp *provider.ConfigureResponse, name, envN
 				" or use the %s environment variable.", name, envName),
 		)
 	} else {
-		resp.Diagnostics.AddAttributeError(
+		diags.AddAttributeError(
 			path.Root(name),
 			"Missing AAP API "+name,
 			fmt.Sprintf("The provider cannot create the AAP API client as there is a missing or empty value for the AAP API %s. "+
@@ -99,15 +109,15 @@ func (p *aapProvider) Configure(ctx context.Context, req provider.ConfigureReque
 
 	// If practitioner provided a configuration value for any of the
 	// attributes, it must be a known value.
-	config.checkUnknownValue(resp)
+	config.checkUnknownValue(&resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	var host, username, password string
+	var host, username, password, token string
 	var insecureSkipVerify bool
 	var timeout int64
-	config.ReadValues(&host, &username, &password, &insecureSkipVerify, &timeout, resp)
+	config.ReadValues(&host, &username, &password, &token, &insecureSkipVerify, &timeout, resp)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -116,15 +126,22 @@ func (p *aapProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	// errors with provider-specific guidance.
 
 	if len(host) == 0 {
-		AddConfigurationAttributeError(resp, "host", "AAP_HOSTNAME", false)
+		AddConfigurationAttributeError(&resp.Diagnostics, "host", "AAP_HOSTNAME", false)
 	}
 
-	if len(username) == 0 {
-		AddConfigurationAttributeError(resp, "username", "AAP_USERNAME", false)
-	}
-
-	if len(password) == 0 {
-		AddConfigurationAttributeError(resp, "password", "AAP_PASSWORD", false)
+	if len(token) == 0 && len(username) == 0 && len(password) == 0 {
+		// No authentication method at all, fail with all errors
+		AddConfigurationAttributeError(&resp.Diagnostics, "token", "AAP_TOKEN", false)
+		AddConfigurationAttributeError(&resp.Diagnostics, "username", "AAP_USERNAME", false)
+		AddConfigurationAttributeError(&resp.Diagnostics, "password", "AAP_PASSWORD", false)
+	} else if len(token) == 0 {
+		// No token, but may have username and password, report error if either is missing
+		if len(username) == 0 {
+			AddConfigurationAttributeError(&resp.Diagnostics, "username", "AAP_USERNAME", false)
+		}
+		if len(password) == 0 {
+			AddConfigurationAttributeError(&resp.Diagnostics, "password", "AAP_PASSWORD", false)
+		}
 	}
 
 	if resp.Diagnostics.HasError() {
@@ -132,7 +149,19 @@ func (p *aapProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	}
 
 	// Create a new http client using the configuration values
-	client, diags := NewClient(host, &username, &password, insecureSkipVerify, timeout)
+	var authenticator AAPClientAuthenticator
+	if len(token) > 0 {
+		authenticator, diags = NewTokenAuthenticator(&token)
+	} else {
+		authenticator, diags = NewBasicAuthenticator(&username, &password)
+	}
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, diags := NewClient(host, authenticator, insecureSkipVerify, timeout)
 	resp.Diagnostics.Append(diags...)
 
 	// Make the http client available during DataSource and Resource
@@ -167,29 +196,34 @@ type aapProviderModel struct {
 	Host               types.String `tfsdk:"host"`
 	Username           types.String `tfsdk:"username"`
 	Password           types.String `tfsdk:"password"`
+	Token              types.String `tfsdk:"token"`
 	InsecureSkipVerify types.Bool   `tfsdk:"insecure_skip_verify"`
 	Timeout            types.Int64  `tfsdk:"timeout"`
 }
 
-func (p *aapProviderModel) checkUnknownValue(resp *provider.ConfigureResponse) {
+func (p *aapProviderModel) checkUnknownValue(diags *diag.Diagnostics) {
 	if p.Host.IsUnknown() {
-		AddConfigurationAttributeError(resp, "host", "AAP_HOSTNAME", true)
+		AddConfigurationAttributeError(diags, "host", "AAP_HOSTNAME", true)
 	}
 
 	if p.Username.IsUnknown() {
-		AddConfigurationAttributeError(resp, "username", "AAP_USERNAME", true)
+		AddConfigurationAttributeError(diags, "username", "AAP_USERNAME", true)
 	}
 
 	if p.Password.IsUnknown() {
-		AddConfigurationAttributeError(resp, "password", "AAP_PASSWORD", true)
+		AddConfigurationAttributeError(diags, "password", "AAP_PASSWORD", true)
+	}
+
+	if p.Token.IsUnknown() {
+		AddConfigurationAttributeError(diags, "token", "AAP_TOKEN", true)
 	}
 
 	if p.InsecureSkipVerify.IsUnknown() {
-		AddConfigurationAttributeError(resp, "insecure_skip_verify", "AAP_INSECURE_SKIP_VERIFY", true)
+		AddConfigurationAttributeError(diags, "insecure_skip_verify", "AAP_INSECURE_SKIP_VERIFY", true)
 	}
 
 	if p.Timeout.IsUnknown() {
-		AddConfigurationAttributeError(resp, "timeout", "AAP_TIMEOUT", true)
+		AddConfigurationAttributeError(diags, "timeout", "AAP_TIMEOUT", true)
 	}
 }
 
@@ -198,7 +232,7 @@ const (
 	DefaultInsecureSkipVerify = false // Default value for insecure skip verify
 )
 
-func (p *aapProviderModel) ReadValues(host, username, password *string, insecureSkipVerify *bool,
+func (p *aapProviderModel) ReadValues(host, username, password *string, token *string, insecureSkipVerify *bool,
 	timeout *int64, resp *provider.ConfigureResponse) {
 	// Set default values from env variables
 
@@ -207,25 +241,51 @@ func (p *aapProviderModel) ReadValues(host, username, password *string, insecure
 	if *host == "" {
 		*host = os.Getenv("AAP_HOST")
 	}
-	*username = os.Getenv("AAP_USERNAME")
-	*password = os.Getenv("AAP_PASSWORD")
-
-	*insecureSkipVerify = DefaultInsecureSkipVerify
-	var err error
 
 	// Read host from user configuration
 	if !p.Host.IsNull() {
 		*host = p.Host.ValueString()
 	}
-	// Read username from user configuration
-	if !p.Username.IsNull() {
-		*username = p.Username.ValueString()
-	}
-	// Read password from user configuration
-	if !p.Password.IsNull() {
-		*password = p.Password.ValueString()
+
+	*token = os.Getenv("AAP_TOKEN")
+	if !p.Token.IsNull() {
+		// Read token from user configuration
+		*token = p.Token.ValueString()
 	}
 
+	if len(*token) > 0 {
+		if !p.Username.IsNull() {
+			resp.Diagnostics.AddAttributeWarning(
+				path.Root("username"),
+				"Inconsistent configuration for username",
+				"When token is configured for authentication, username will be ignored. Please remove username from your configuration.",
+			)
+		}
+		if !p.Password.IsNull() {
+			resp.Diagnostics.AddAttributeWarning(
+				path.Root("username"),
+				"Inconsistent configuration for password",
+				"When token is configured for authentication, password will be ignored. Please remove passworf from your configuration",
+			)
+		}
+	} else {
+		// Token not provided, proceed with username/password
+		*username = os.Getenv("AAP_USERNAME")
+		*password = os.Getenv("AAP_PASSWORD")
+
+		// Read username from user configuration
+		if !p.Username.IsNull() {
+			*username = p.Username.ValueString()
+		}
+		// Read password from user configuration
+		if !p.Password.IsNull() {
+			*password = p.Password.ValueString()
+		}
+	}
+
+	// setting default insecure skip verify value
+	*insecureSkipVerify = DefaultInsecureSkipVerify
+	var err error
 	if !p.InsecureSkipVerify.IsNull() {
 		*insecureSkipVerify = p.InsecureSkipVerify.ValueBool()
 	} else if boolValue := os.Getenv("AAP_INSECURE_SKIP_VERIFY"); boolValue != "" {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -26,12 +27,24 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 	providerName: providerserver.NewProtocol6WithError(New("test")()),
 }
 
+// testAccPreCheck is used by acceptance tests in the PreCheck block.
 func testAccPreCheck(t *testing.T) {
 	requiredAAPEnvVars := map[string]string{
 		"AAP_HOSTNAME":             "https://localhost:8043",
 		"AAP_USERNAME":             "",
 		"AAP_PASSWORD":             "",
 		"AAP_INSECURE_SKIP_VERIFY": "true",
+	}
+
+	_, tokenSet := os.LookupEnv("AAP_TOKEN")
+	if tokenSet {
+		t.Log("'AAP_TOKEN' is set, using token authentication in acceptance tests")
+		// Token is set in environment, use that
+		delete(requiredAAPEnvVars, "AAP_USERNAME")
+		delete(requiredAAPEnvVars, "AAP_PASSWORD")
+		requiredAAPEnvVars["AAP_TOKEN"] = ""
+	} else {
+		t.Log("'AAP_TOKEN' is not set, using basic authentication in acceptance tests")
 	}
 
 	for k, d := range requiredAAPEnvVars {
@@ -52,10 +65,22 @@ func testMethodResource(method string, urlPath string) ([]byte, error) {
 	if host == "" {
 		host = os.Getenv("AAP_HOST")
 	}
+
+	// Prefer AAP_TOKEN, fallback to AAP_USERNAME / AAP_PASSWORD
+	token := os.Getenv("AAP_TOKEN")
 	username := os.Getenv("AAP_USERNAME")
 	password := os.Getenv("AAP_PASSWORD")
-
-	client, diags := NewClient(host, &username, &password, true, 0)
+	var authenticator AAPClientAuthenticator
+	var diags diag.Diagnostics
+	if len(token) > 0 {
+		authenticator, diags = NewTokenAuthenticator(&token)
+	} else {
+		authenticator, diags = NewBasicAuthenticator(&username, &password)
+	}
+	if diags.HasError() {
+		return nil, fmt.Errorf("%v", diags.Errors())
+	}
+	client, diags := NewClient(host, authenticator, true, 0)
 	if diags.HasError() {
 		return nil, fmt.Errorf("%v", diags.Errors())
 	}
@@ -91,9 +116,11 @@ func TestReadValues(t *testing.T) {
 		Host               string
 		Username           string
 		Password           string
+		Token              string
 		InsecureSkipVerify bool
 		Timeout            int64
 		Errors             int
+		Warnings           int
 	}{
 		{
 			name:               "No defined values",
@@ -102,12 +129,28 @@ func TestReadValues(t *testing.T) {
 			Host:               "",
 			Username:           "",
 			Password:           "",
+			Token:              "",
 			InsecureSkipVerify: DefaultInsecureSkipVerify,
 			Timeout:            DefaultTimeOut,
 			Errors:             0,
 		},
 		{
-			name:   "Using env variables only",
+			name:   "Using env variables only, with token",
+			config: aapProviderModel{},
+			envVars: map[string]string{
+				"AAP_HOSTNAME":             "https://172.0.0.1:9000",
+				"AAP_TOKEN":                "test-token",
+				"AAP_INSECURE_SKIP_VERIFY": "true",
+				"AAP_TIMEOUT":              "30",
+			},
+			Host:               "https://172.0.0.1:9000",
+			Token:              "test-token",
+			InsecureSkipVerify: true,
+			Timeout:            30,
+			Errors:             0,
+		},
+		{
+			name:   "Using env variables only, with username/password",
 			config: aapProviderModel{},
 			envVars: map[string]string{
 				"AAP_HOSTNAME":             "https://172.0.0.1:9000",
@@ -119,6 +162,7 @@ func TestReadValues(t *testing.T) {
 			Host:               "https://172.0.0.1:9000",
 			Username:           "user988",
 			Password:           "@pass123#",
+			Token:              "",
 			InsecureSkipVerify: true,
 			Timeout:            30,
 			Errors:             0,
@@ -206,18 +250,54 @@ func TestReadValues(t *testing.T) {
 			Timeout:            DefaultTimeOut,
 			Errors:             0,
 		},
+		{
+			name:   "Using env variables for configuration, ignores username/password when token is set",
+			config: aapProviderModel{},
+			envVars: map[string]string{
+				"AAP_HOSTNAME": "https://172.0.0.1:9000",
+				"AAP_USERNAME": "ansible",
+				"AAP_PASSWORD": "testing#$%",
+				"AAP_TOKEN":    "test-token",
+			},
+			Host:               "https://172.0.0.1:9000",
+			Username:           "",
+			Password:           "",
+			Token:              "test-token",
+			InsecureSkipVerify: false,
+			Timeout:            5,
+			Errors:             0,
+		},
+		{
+			name: "Using configuration, ignores username/password when token is set and reports warnings",
+			config: aapProviderModel{
+				Host:     types.StringValue("https://172.0.0.1:9000"),
+				Username: types.StringValue("user988"),
+				Password: types.StringValue("@pass123#"),
+				Token:    types.StringValue("test-token"),
+			},
+			envVars:            map[string]string{},
+			Host:               "https://172.0.0.1:9000",
+			Username:           "",
+			Password:           "",
+			Token:              "test-token",
+			InsecureSkipVerify: false,
+			Timeout:            5,
+			Errors:             0,
+			Warnings:           2,
+		},
 	}
 	var providerEnvVars = []string{
 		"AAP_HOSTNAME",
 		"AAP_HOST",
 		"AAP_USERNAME",
+		"AAP_TOKEN",
 		"AAP_PASSWORD",
 		"AAP_INSECURE_SKIP_VERIFY",
 		"AAP_TIMEOUT",
 	}
 	for _, tc := range testTable {
 		t.Run(tc.name, func(t *testing.T) {
-			var host, username, password string
+			var host, username, password, token string
 			var insecureSkipVerify bool
 			var timeout int64
 			var resp provider.ConfigureResponse
@@ -230,7 +310,7 @@ func TestReadValues(t *testing.T) {
 				}
 			}
 			// ReadValues()
-			tc.config.ReadValues(&host, &username, &password, &insecureSkipVerify, &timeout, &resp)
+			tc.config.ReadValues(&host, &username, &password, &token, &insecureSkipVerify, &timeout, &resp)
 			if tc.Errors != resp.Diagnostics.ErrorsCount() {
 				t.Errorf("Errors count expected=(%d) - found=(%d)", tc.Errors, resp.Diagnostics.ErrorsCount())
 			} else if tc.Errors == 0 {
@@ -243,12 +323,18 @@ func TestReadValues(t *testing.T) {
 				if password != tc.Password {
 					t.Errorf("Password values differ expected=(%s) - computed=(%s)", tc.Password, password)
 				}
+				if token != tc.Token {
+					t.Errorf("Token values differ expected=(%s) - computed=(%s)", tc.Token, token)
+				}
 				if insecureSkipVerify != tc.InsecureSkipVerify {
 					t.Errorf("InsecureSkipVerify values differ expected=(%v) - computed=(%v)", tc.InsecureSkipVerify, insecureSkipVerify)
 				}
 				if timeout != tc.Timeout {
 					t.Errorf("Timeout values differ expected=(%d) - computed=(%d)", tc.Timeout, timeout)
 				}
+			}
+			if tc.Warnings != resp.Diagnostics.WarningsCount() {
+				t.Errorf("Warnings count expected=(%d) - found=(%d)", tc.Warnings, resp.Diagnostics.WarningsCount())
 			}
 		})
 	}
@@ -344,14 +430,14 @@ func TestCheckUnknownValue(t *testing.T) {
 
 	for _, tc := range testTable {
 		t.Run(tc.name, func(t *testing.T) {
-			response := provider.ConfigureResponse{}
-			tc.model.checkUnknownValue(&response)
-			actualError := response.Diagnostics.HasError()
+			diags := diag.Diagnostics{}
+			tc.model.checkUnknownValue(&diags)
+			actualError := diags.HasError()
 			if actualError != tc.expectError {
 				t.Errorf("Expected errors '%v', actual '%v'", tc.expectError, actualError)
 			}
 			found := false
-			for _, err := range response.Diagnostics.Errors() {
+			for _, err := range diags.Errors() {
 				if strings.Contains(err.Summary(), tc.errorSummary) &&
 					strings.Contains(err.Detail(), tc.errorDetail) {
 					found = true
@@ -359,7 +445,7 @@ func TestCheckUnknownValue(t *testing.T) {
 			}
 			if !found && tc.expectError {
 				t.Errorf("Did not find error with expected summary '%v', detail containing '%v'. Actual errors %v",
-					tc.errorSummary, tc.errorDetail, response.Diagnostics.Errors())
+					tc.errorSummary, tc.errorDetail, diags.Errors())
 			}
 		})
 	}
@@ -370,7 +456,7 @@ func TestConfigure(t *testing.T) {
 		name         string
 		configValues map[string]tftypes.Value
 		envVars      map[string]string
-		expectError  bool
+		expectErrors int
 		errorSummary string
 		errorDetail  string
 	}{
@@ -380,12 +466,27 @@ func TestConfigure(t *testing.T) {
 				"host":                 tftypes.NewValue(tftypes.String, ""),
 				"username":             tftypes.NewValue(tftypes.String, "username"),
 				"password":             tftypes.NewValue(tftypes.String, "password"),
+				"token":                tftypes.NewValue(tftypes.String, ""),
 				"insecure_skip_verify": tftypes.NewValue(tftypes.Bool, false),
 				"timeout":              tftypes.NewValue(tftypes.Number, 30),
 			},
-			expectError:  true,
+			expectErrors: 1,
 			errorSummary: "Missing AAP API host",
 			errorDetail:  "AAP_HOSTNAME",
+		},
+		{
+			name: "Missing token",
+			configValues: map[string]tftypes.Value{
+				"host":                 tftypes.NewValue(tftypes.String, "http://localhost"),
+				"username":             tftypes.NewValue(tftypes.String, ""),
+				"password":             tftypes.NewValue(tftypes.String, ""),
+				"token":                tftypes.NewValue(tftypes.String, ""),
+				"insecure_skip_verify": tftypes.NewValue(tftypes.Bool, false),
+				"timeout":              tftypes.NewValue(tftypes.Number, 30),
+			},
+			expectErrors: 3,
+			errorSummary: "Missing AAP API token",
+			errorDetail:  "AAP_TOKEN",
 		},
 		{
 			name: "Missing username",
@@ -393,10 +494,11 @@ func TestConfigure(t *testing.T) {
 				"host":                 tftypes.NewValue(tftypes.String, "http://localhost"),
 				"username":             tftypes.NewValue(tftypes.String, ""),
 				"password":             tftypes.NewValue(tftypes.String, "password"),
+				"token":                tftypes.NewValue(tftypes.String, ""),
 				"insecure_skip_verify": tftypes.NewValue(tftypes.Bool, false),
 				"timeout":              tftypes.NewValue(tftypes.Number, 30),
 			},
-			expectError:  true,
+			expectErrors: 1,
 			errorSummary: "Missing AAP API username",
 			errorDetail:  "AAP_USERNAME",
 		},
@@ -406,10 +508,11 @@ func TestConfigure(t *testing.T) {
 				"host":                 tftypes.NewValue(tftypes.String, "http://localhost"),
 				"username":             tftypes.NewValue(tftypes.String, "username"),
 				"password":             tftypes.NewValue(tftypes.String, ""),
+				"token":                tftypes.NewValue(tftypes.String, ""),
 				"insecure_skip_verify": tftypes.NewValue(tftypes.Bool, false),
 				"timeout":              tftypes.NewValue(tftypes.Number, 30),
 			},
-			expectError:  true,
+			expectErrors: 1,
 			errorSummary: "Missing AAP API password",
 			errorDetail:  "AAP_PASSWORD",
 		},
@@ -431,6 +534,7 @@ func TestConfigure(t *testing.T) {
 					"host":                 tftypes.String,
 					"username":             tftypes.String,
 					"password":             tftypes.String,
+					"token":                tftypes.String,
 					"insecure_skip_verify": tftypes.Bool,
 					"timeout":              tftypes.Number,
 				},
@@ -449,9 +553,9 @@ func TestConfigure(t *testing.T) {
 
 			p.Configure(context.TODO(), request, &response)
 
-			actualError := response.Diagnostics.HasError()
-			if actualError != tc.expectError {
-				t.Errorf("Expected errors '%v', actual '%v'", tc.expectError, actualError)
+			actualErrors := response.Diagnostics.ErrorsCount()
+			if actualErrors != tc.expectErrors {
+				t.Errorf("Expected '%v' errors, actual count '%v'", tc.expectErrors, actualErrors)
 			}
 			found := false
 			for _, err := range response.Diagnostics.Errors() {
@@ -460,7 +564,7 @@ func TestConfigure(t *testing.T) {
 					found = true
 				}
 			}
-			if !found && tc.expectError {
+			if !found && tc.expectErrors > 0 {
 				t.Errorf("Did not find error with expected summary '%v', detail containing '%v'. Actual errors %v",
 					tc.errorSummary, tc.errorDetail, response.Diagnostics.Errors())
 			}

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -9,13 +9,20 @@ description: |-
 The Red Hat Ansible Automation Platform (AAP) provider allows Terraform to reference and manage
 a subset of AAP resources.
 
-
 ## Example Usage
 
 {{ tffile .ExampleFile }}
 {{ .SchemaMarkdown | trimspace }}
 
-## Supported Platform
+## Authentication Methods
+
+The provider supports multiple authentication methods with Red Hat Ansible Automation Platform (AAP). Token Authentication is the recommend method, since users can manage tokens for specific integrations (e.g. Terraform), limit token access, and have full control over token lifecycle.
+
+For more information on creating tokens, see [Red Hat Ansible Automation Platform 2.5 - Access management and Authentication](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/access_management_and_authentication/gw-token-based-authentication#proc-controller-apps-create-tokens) for AAP 2.5+ or [Red Hat Ansible Automation Platform 2.4 - Managing Users in automation controller](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/automation_controller_user_guide/assembly-controller-users#proc-controller-user-tokens) for AAP 2.4.
+
+The provider also supports basic authentication with a username and password. If a token is configured, username and password will be ignored.
+
+## Supported Platforms
 
 - Linux AMD64 and ARM64
 - macOS AMD64 and ARM64


### PR DESCRIPTION
This PR integrates the changes from #141 into the provider to support token authentication in addition to basic (username/password) auth. Running acceptance tests is simplified with the changes in #142 that create a token to use.

- Refactors client to use an `AAPClientAuthenticator`, which can support either basic or token auth
- Updates provider to prefer token auth
- Updates unit tests (added in #138) to test
- Updates documentation in schema, template, and examples to show token usage and links to AAP docs. Regenerates markdown docs.
- Creates a changelog fragment noting a major_change

Part 3 of https://issues.redhat.com/browse/AAP-46311