### PR TITLE
[AAP-52752] 2: Implement `aap_eda_eventstream` action

### DIFF
--- a/internal/provider/eda_eventstream_action.go
+++ b/internal/provider/eda_eventstream_action.go
@@ -1,0 +1,244 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/action/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var (
+	_ action.Action = (*EDAEventStreamAction)(nil)
+)
+
+func NewEDAEventStreamAction() action.Action {
+	return &EDAEventStreamAction{}
+}
+
+type EDAEventStreamAction struct{}
+
+// Metadata
+func (a *EDAEventStreamAction) Metadata(ctx context.Context, req action.MetadataRequest, resp *action.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_eda_eventstream"
+}
+
+// Schema
+func (a *EDAEventStreamAction) Schema(ctx context.Context, req action.SchemaRequest, resp *action.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Sends an event payload to an EDA Event Stream URL",
+		Attributes: map[string]schema.Attribute{
+			"limit": schema.StringAttribute{
+				Description: "Ansible limit for job execution",
+				Required:    true,
+			},
+			"template_type": schema.StringAttribute{
+				Description: "Template type: either job or workflow_job",
+				Required:    true,
+			},
+			"job_template_name": schema.StringAttribute{
+				Description: "Job Template Name (Used when template_type is job)",
+				Optional:    true,
+			},
+			"workflow_job_template_name": schema.StringAttribute{
+				Description: "Workflow Job Template Name (Used when template_type is workflow_job)",
+				Optional:    true,
+			},
+			"organization_name": schema.StringAttribute{
+				Description: "Organization Name",
+				Required:    true,
+			},
+			"event_stream_config": schema.SingleNestedAttribute{
+				Description: "Details for the EDA Event Stream",
+				Required:    true,
+				Attributes: map[string]schema.Attribute{
+					"url": schema.StringAttribute{
+						Description: "URL to receive the event POST",
+						Required:    true,
+					},
+					"insecure_skip_verify": schema.BoolAttribute{
+						Description: "Disable TLS verification (insecure)",
+						Optional:    true,
+					},
+					"username": schema.StringAttribute{
+						Description: "Username to use when performing the POST to the Event Stream URL",
+						Required:    true,
+					},
+					"password": schema.StringAttribute{
+						Description: "Password to use when performing the POST to the Event Stream URL",
+						Required:    true,
+					},
+				},
+			},
+		},
+	}
+}
+
+type EventStreamConfigModel struct {
+	Url                types.String `tfsdk:"url"`
+	Username           types.String `tfsdk:"username"`
+	Password           types.String `tfsdk:"password"`
+	InsecureSkipVerify types.Bool   `tfsdk:"insecure_skip_verify"`
+}
+
+type EventStreamActionModel struct {
+	Limit                   types.String           `tfsdk:"limit"`
+	TemplateType            types.String           `tfsdk:"template_type"`
+	JobTemplateName         types.String           `tfsdk:"job_template_name"`
+	WorkflowJobTemplateName types.String           `tfsdk:"workflow_job_template_name"`
+	OrganizationName        types.String           `tfsdk:"organization_name"`
+	EventStreamConfig       EventStreamConfigModel `tfsdk:"event_stream_config"`
+}
+
+type EventStreamConfigAPIModel struct {
+	Limit                   string `json:"limit"`
+	TemplateType            string `json:"template_type"`
+	JobTemplateName         string `json:"job_template_name"`
+	WorkflowJobTemplateName string `json:"workflow_job_template_name"`
+	OrganizationName        string `json:"organization_name"`
+}
+
+func (m *EventStreamActionModel) CreateEventPayload() ([]byte, diag.Diagnostics) {
+	// Convert to the API Model
+	payload := EventStreamConfigAPIModel{
+		TemplateType:            m.TemplateType.ValueString(),
+		JobTemplateName:         m.JobTemplateName.ValueString(),
+		WorkflowJobTemplateName: m.WorkflowJobTemplateName.ValueString(),
+		OrganizationName:        m.OrganizationName.ValueString(),
+		Limit:                   m.Limit.ValueString(),
+	}
+
+	jsonPayload, err := json.Marshal(payload)
+	if err != nil {
+		var diags diag.Diagnostics
+		diags.AddError(
+			"Error marshaling event payload body",
+			fmt.Sprintf("Unable to create event stream action event payload, unexpected error: %s", err.Error()),
+		)
+		return nil, diags
+	}
+	return jsonPayload, nil
+}
+
+// Create an http POST request to the configured Event Stream URL using basic auth
+func (m *EventStreamActionModel) CreateRequest(ctx context.Context, body io.Reader) (*http.Request, diag.Diagnostics) {
+	url := m.EventStreamConfig.Url.ValueString()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+	if err != nil {
+		var diags diag.Diagnostics
+		diags.AddError(
+			"Error creating request",
+			fmt.Sprintf("Unable to create event stream action request, unexpected error: %s", err.Error()),
+		)
+		return nil, diags
+	}
+
+	const EDAEventStreamActionContentType = "application/json"
+	req.Header.Set("Content-Type", EDAEventStreamActionContentType)
+
+	// Only Basic auth supported at this time
+	req.SetBasicAuth(m.EventStreamConfig.Username.ValueString(), m.EventStreamConfig.Password.ValueString())
+	return req, nil
+}
+
+// Create an http.Client
+func (m *EventStreamActionModel) CreateClient() *http.Client {
+	insecureSkipVerify := m.EventStreamConfig.InsecureSkipVerify.ValueBool()
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify},
+	}
+	client := &http.Client{Transport: tr}
+	return client
+}
+
+func (a *EDAEventStreamAction) ExecuteRequest(client *http.Client, req *http.Request) ([]byte, diag.Diagnostics) {
+	// Perform the request
+	hresp, err := client.Do(req)
+	if err != nil {
+		var diags diag.Diagnostics
+		diags.AddError(
+			"Error executing request",
+			fmt.Sprintf("Unable to execute event stream action request, unexpected error %s", err.Error()),
+		)
+		return nil, diags
+	}
+	// Close the response body when done
+	defer hresp.Body.Close()
+
+	// Handle the response
+	body, err := io.ReadAll(hresp.Body)
+	if err != nil {
+		var diags diag.Diagnostics
+		diags.AddError(
+			"Error handling response",
+			fmt.Sprintf("Unable to handle response from event stream action request, unexpected error %s", err.Error()),
+		)
+		return nil, diags
+	}
+
+	// Check the status code, should be created
+	validStatusCodes := []int{
+		http.StatusCreated,
+		http.StatusOK,
+	}
+	if !slices.Contains(validStatusCodes, hresp.StatusCode) {
+		var diags diag.Diagnostics
+		diags.AddError(
+			"Unexpected response status code",
+			fmt.Sprintf("Received status code %v from event stream action request. Expecting one of %v, response body %q", hresp.StatusCode, validStatusCodes, string(body)),
+		)
+		return nil, diags
+	}
+
+	// OK we have a successful response
+	return body, nil
+}
+
+// Invoke the action
+func (a *EDAEventStreamAction) Invoke(ctx context.Context, req action.InvokeRequest, resp *action.InvokeResponse) {
+	var config EventStreamActionModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	jsonPayload, diags := config.CreateEventPayload()
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	url := config.EventStreamConfig.Url.ValueString()
+
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: fmt.Sprintf("Preparing event stream POST to %s", url),
+	})
+
+	// Create the request
+	jsonPayloadReader := bytes.NewReader(jsonPayload)
+	hreq, diags := config.CreateRequest(ctx, jsonPayloadReader)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client := config.CreateClient()
+	body, diags := a.ExecuteRequest(client, hreq)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: fmt.Sprintf("Sent event stream POST to %s, body %q", url, string(body)),
+	})
+}

--- a/internal/provider/eda_eventstream_action.go
+++ b/internal/provider/eda_eventstream_action.go
@@ -106,7 +106,21 @@ type EventStreamConfigAPIModel struct {
 	OrganizationName        string `json:"organization_name"`
 }
 
+type JSONMarshaler interface {
+	Marshal(v any) ([]byte, error)
+}
+
+type defaultJSONMarshaler struct{}
+
+func (d defaultJSONMarshaler) Marshal(v any) ([]byte, error) {
+	return json.Marshal(v)
+}
+
 func (m *EventStreamActionModel) CreateEventPayload() ([]byte, diag.Diagnostics) {
+	return m.CreateEventPayloadWithMarshaler(defaultJSONMarshaler{})
+}
+
+func (m *EventStreamActionModel) CreateEventPayloadWithMarshaler(marshaler JSONMarshaler) ([]byte, diag.Diagnostics) {
 	// Convert to the API Model
 	payload := EventStreamConfigAPIModel{
 		TemplateType:            m.TemplateType.ValueString(),
@@ -116,7 +130,7 @@ func (m *EventStreamActionModel) CreateEventPayload() ([]byte, diag.Diagnostics)
 		Limit:                   m.Limit.ValueString(),
 	}
 
-	jsonPayload, err := json.Marshal(payload)
+	jsonPayload, err := marshaler.Marshal(payload)
 	if err != nil {
 		var diags diag.Diagnostics
 		diags.AddError(

--- a/internal/provider/eda_eventstream_action.go
+++ b/internal/provider/eda_eventstream_action.go
@@ -32,7 +32,7 @@ func (a *EDAEventStreamAction) Metadata(_ context.Context, req action.MetadataRe
 }
 
 // Schema
-func (a *EDAEventStreamAction) Schema(_ context.Context, req action.SchemaRequest, resp *action.SchemaResponse) {
+func (a *EDAEventStreamAction) Schema(_ context.Context, _ action.SchemaRequest, resp *action.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: "Sends an event payload to an EDA Event Stream URL",
 		Attributes: map[string]schema.Attribute{

--- a/internal/provider/eda_eventstream_action.go
+++ b/internal/provider/eda_eventstream_action.go
@@ -159,7 +159,11 @@ func (m *EventStreamActionModel) CreateClient() *http.Client {
 	return client
 }
 
-func (a *EDAEventStreamAction) ExecuteRequest(client *http.Client, req *http.Request) ([]byte, diag.Diagnostics) {
+type HttpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+func (a *EDAEventStreamAction) ExecuteRequest(client HttpClient, req *http.Request) ([]byte, diag.Diagnostics) {
 	// Perform the request
 	hresp, err := client.Do(req)
 	if err != nil {

--- a/internal/provider/eda_eventstream_action.go
+++ b/internal/provider/eda_eventstream_action.go
@@ -27,12 +27,12 @@ func NewEDAEventStreamAction() action.Action {
 type EDAEventStreamAction struct{}
 
 // Metadata
-func (a *EDAEventStreamAction) Metadata(ctx context.Context, req action.MetadataRequest, resp *action.MetadataResponse) {
+func (a *EDAEventStreamAction) Metadata(_ context.Context, req action.MetadataRequest, resp *action.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_eda_eventstream"
 }
 
 // Schema
-func (a *EDAEventStreamAction) Schema(ctx context.Context, req action.SchemaRequest, resp *action.SchemaResponse) {
+func (a *EDAEventStreamAction) Schema(_ context.Context, req action.SchemaRequest, resp *action.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: "Sends an event payload to an EDA Event Stream URL",
 		Attributes: map[string]schema.Attribute{
@@ -193,7 +193,8 @@ func (a *EDAEventStreamAction) ExecuteRequest(client *http.Client, req *http.Req
 		var diags diag.Diagnostics
 		diags.AddError(
 			"Unexpected response status code",
-			fmt.Sprintf("Received status code %v from event stream action request. Expecting one of %v, response body %q", hresp.StatusCode, validStatusCodes, string(body)),
+			fmt.Sprintf("Received status code %v from event stream action request. Expecting one of %v, response body %q",
+				hresp.StatusCode, validStatusCodes, string(body)),
 		)
 		return nil, diags
 	}

--- a/internal/provider/eda_eventstream_action_test.go
+++ b/internal/provider/eda_eventstream_action_test.go
@@ -2,8 +2,18 @@ package provider
 
 import (
 	"context"
-	fwaction "github.com/hashicorp/terraform-plugin-framework/action"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+
+	fwaction "github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 func TestEDAEventStreamActionSchema(t *testing.T) {
@@ -11,9 +21,9 @@ func TestEDAEventStreamActionSchema(t *testing.T) {
 
 	ctx := context.Background()
 	schemaRequest := fwaction.SchemaRequest{}
-	schemaResponse := &fwaction.SchemaResponse{}
+	schemaResponse := fwaction.SchemaResponse{}
 
-	NewEDAEventStreamAction().Schema(ctx, schemaRequest, schemaResponse)
+	NewEDAEventStreamAction().Schema(ctx, schemaRequest, &schemaResponse)
 
 	if schemaResponse.Diagnostics.HasError() {
 		t.Fatalf("Schema method diagnostics: %+v", schemaResponse.Diagnostics)
@@ -25,4 +35,216 @@ func TestEDAEventStreamActionSchema(t *testing.T) {
 	if diagnostics.HasError() {
 		t.Fatalf("Schema validation diagnostics: %+v", diagnostics)
 	}
+}
+
+// Test Metadata
+func TestEDAEventStreamActionMetadata(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	metadataRequest := fwaction.MetadataRequest{
+		ProviderTypeName: "test",
+	}
+	metadataResponse := fwaction.MetadataResponse{}
+
+	NewEDAEventStreamAction().Metadata(ctx, metadataRequest, &metadataResponse)
+	expected := "test_eda_eventstream"
+	actual := metadataResponse.TypeName
+	if expected != actual {
+		t.Errorf("Expected metadata TypeName %q, received %q", expected, actual)
+	}
+}
+
+// Test CreateEventPayload
+func TestCreateEventPayload(t *testing.T) {
+	t.Parallel()
+	// Creates a JSON
+	// write a test table here
+	model := EventStreamActionModel{
+		Limit: types.StringValue("test-limit"),
+	}
+	buf, _ := model.CreateEventPayload()
+	expectedItem := `"limit":"test-limit"`
+	actual := string(buf)
+	if !strings.Contains(actual, expectedItem) {
+		t.Errorf("Expected to find item %q in payload, actual %q", expectedItem, actual)
+	}
+	// TODO: Test error case if possible
+}
+
+// Test CreateRequest
+func TestCreateRequest(t *testing.T) {
+	t.Parallel()
+	model := EventStreamActionModel{
+		EventStreamConfig: EventStreamConfigModel{
+			Username: types.StringValue("username"),
+			Password: types.StringValue("password"),
+			Url:      types.StringValue("https://test.example.org"),
+		},
+	}
+
+	body := strings.NewReader("test-body")
+	req, _ := model.CreateRequest(context.TODO(), body)
+	actual := req.Header["Authorization"][0]
+	// base64 encoding of string "username:password"
+	expected := "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+	if actual != expected {
+		t.Errorf("Expected request to be created with basic auth header %q, actual %q", expected, actual)
+	}
+	// TODO: Test that it's a POST and the body
+	// TODO: Test the failure cases, maybe with a canceled context
+}
+
+func TestCreateClient(t *testing.T) {
+	t.Parallel()
+	model := EventStreamActionModel{
+		EventStreamConfig: EventStreamConfigModel{
+			InsecureSkipVerify: types.BoolValue(true),
+		},
+	}
+	client := model.CreateClient()
+	expected := true
+	actual := client.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify
+	if actual != expected {
+		t.Errorf("Expected client transport be created with InsecureSkipVerify %v, actual %v", expected, actual)
+	}
+	// TODO: Check other value of insecure
+}
+
+type MockClient struct {
+	StatusCode int
+	Body       string
+}
+
+func (m *MockClient) Do(_ *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: m.StatusCode,
+		Body:       io.NopCloser(strings.NewReader(m.Body)),
+	}, nil
+}
+
+// Test ExecuteRequest
+func TestExecuteRequest(t *testing.T) {
+	t.Parallel()
+	a := EDAEventStreamAction{}
+
+	client := MockClient{StatusCode: http.StatusOK, Body: "test"}
+	body, diags := a.ExecuteRequest(&client, nil)
+	if diags.HasError() {
+		t.Errorf("Unexpected error in ExecuteRequest: %s", diags.Errors())
+	}
+
+	expected := "test"
+	actual := string(body)
+	if actual != expected {
+		t.Errorf("Expected ExecuteRequest to return body %v, actual %v", expected, actual)
+	}
+	// TODO: Test client.Do error
+	// TODO: Test http error codes
+}
+
+// Acceptance testing will use httptest to run a server and test that actions POST to it
+
+type testHandler struct {
+	callCount     int
+	responseCode  int
+	requestBody   string
+	requestBytes  int
+	requestError  error
+	responseBody  string
+	responseBytes int
+	responseError error
+}
+
+func (h *testHandler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
+	h.callCount += 1
+
+	// Read the request and record the length
+	buffer := make([]byte, req.ContentLength)
+	h.requestBytes, h.requestError = req.Body.Read(buffer)
+	h.requestBody = string(buffer)
+
+	// write the response
+	writer.WriteHeader(h.responseCode)
+	h.responseBytes, h.responseError = writer.Write([]byte(h.responseBody))
+}
+
+// Test Invoke (this should be an acceptance test)
+func TestAccEDAEventStreamAction(t *testing.T) {
+	// Create an http test server
+	handler := testHandler{
+		responseCode: http.StatusOK,
+	}
+	testServer := httptest.NewServer(&handler)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() {},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBasicAction("after_create", testServer.URL),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("terraform_data.trigger", "input", "test"),
+					func(_ *terraform.State) error {
+						testServer.Close()
+						return testAccCheckActionReceived(t, &handler)
+					},
+				),
+			},
+		},
+	})
+	// TODO: Test that no actions are fired the second time
+	// TODO: Test that no actions are fired if lifecycle doesn't match
+
+}
+
+func testAccCheckActionReceived(t *testing.T, handler *testHandler) error {
+	t.Helper()
+	// Action should be received
+	expected := 132 // Length of the sample JSON
+	actual := handler.requestBytes
+	if expected != actual {
+		return fmt.Errorf("Expected %v bytes, received %v. Request body %s", expected, actual, handler.requestBody)
+	}
+	if handler.callCount != 1 {
+		return fmt.Errorf("Expected 1 call, received %v.", handler.callCount)
+	}
+
+	expectedBody := `{"limit":"limit","template_type":"job","job_template_name":"template",` +
+		`"workflow_job_template_name":"","organization_name":"Default"}`
+	actualBody := handler.requestBody
+	if actualBody != expectedBody {
+		return fmt.Errorf("Unexpected request body %s", actualBody)
+	}
+	return nil
+}
+
+func testAccBasicAction(trigger_events string, url string) string {
+	return fmt.Sprintf(`
+	resource "terraform_data" "trigger" {
+		input = "test"
+		lifecycle {
+			action_trigger {
+				events = [%s]
+				actions = [action.aap_eda_eventstream.action]
+			}
+		}
+	}
+
+	action "aap_eda_eventstream" "action" {
+		config {
+			limit = "limit"
+			template_type = "job"
+			job_template_name = "template"
+			organization_name = "Default"
+			event_stream_config = {
+				username = "username"
+				password = "password"
+				url = "%s"
+			}
+		}
+
+	}
+	`, trigger_events, url)
 }

--- a/internal/provider/eda_eventstream_action_test.go
+++ b/internal/provider/eda_eventstream_action_test.go
@@ -198,7 +198,6 @@ func TestAccEDAEventStreamAction(t *testing.T) {
 	})
 	// TODO: Test that no actions are fired the second time
 	// TODO: Test that no actions are fired if lifecycle doesn't match
-
 }
 
 func testAccCheckActionReceived(t *testing.T, handler *testHandler) error {

--- a/internal/provider/eda_eventstream_action_test.go
+++ b/internal/provider/eda_eventstream_action_test.go
@@ -1,0 +1,28 @@
+package provider
+
+import (
+	"context"
+	fwaction "github.com/hashicorp/terraform-plugin-framework/action"
+	"testing"
+)
+
+func TestEDAEventStreamActionSchema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	schemaRequest := fwaction.SchemaRequest{}
+	schemaResponse := &fwaction.SchemaResponse{}
+
+	NewEDAEventStreamAction().Schema(ctx, schemaRequest, schemaResponse)
+
+	if schemaResponse.Diagnostics.HasError() {
+		t.Fatalf("Schema method diagnostics: %+v", schemaResponse.Diagnostics)
+	}
+
+	// Validate the schema
+	diagnostics := schemaResponse.Schema.ValidateImplementation(ctx)
+
+	if diagnostics.HasError() {
+		t.Fatalf("Schema validation diagnostics: %+v", diagnostics)
+	}
+}

--- a/internal/provider/eda_eventstream_action_test.go
+++ b/internal/provider/eda_eventstream_action_test.go
@@ -146,6 +146,7 @@ func TestExecuteRequest(t *testing.T) {
 
 type testHandler struct {
 	callCount     int
+	requestMethod string
 	responseCode  int
 	requestBody   string
 	requestBytes  int
@@ -162,6 +163,7 @@ func (h *testHandler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 	buffer := make([]byte, req.ContentLength)
 	h.requestBytes, h.requestError = req.Body.Read(buffer)
 	h.requestBody = string(buffer)
+	h.requestMethod = req.Method
 
 	// write the response
 	writer.WriteHeader(h.responseCode)
@@ -201,6 +203,10 @@ func TestAccEDAEventStreamAction(t *testing.T) {
 
 func testAccCheckActionReceived(t *testing.T, handler *testHandler) error {
 	t.Helper()
+	// should be a POST
+	if handler.requestMethod != http.MethodPost {
+		return fmt.Errorf("Expected method %v, received %v", http.MethodPost, handler.requestMethod)
+	}
 	// Action should be received
 	expected := 132 // Length of the sample JSON
 	actual := handler.requestBytes

--- a/internal/provider/eda_eventstream_action_test.go
+++ b/internal/provider/eda_eventstream_action_test.go
@@ -58,7 +58,7 @@ func TestEDAEventStreamActionMetadata(t *testing.T) {
 // Mock marshaler that always fails
 type failingMarshaler struct{}
 
-func (f failingMarshaler) Marshal(v any) ([]byte, error) {
+func (f failingMarshaler) Marshal(_ any) ([]byte, error) {
 	return nil, errors.New("marshal failed")
 }
 
@@ -67,10 +67,10 @@ func TestCreateEventPayload(t *testing.T) {
 	t.Parallel()
 
 	testTable := []struct {
-		name          string
-		marshaler     JSONMarshaler
-		expectError   bool
-		expectedItem  string
+		name         string
+		marshaler    JSONMarshaler
+		expectError  bool
+		expectedItem string
 	}{
 		{
 			name:         "success with default marshaler",

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -171,10 +171,11 @@ func (p *aapProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	client, diags := NewClient(host, authenticator, insecureSkipVerify, timeout)
 	resp.Diagnostics.Append(diags...)
 
-	// Make the http client available during DataSource and Resource
+	// Make the http client available during DataSource, Resource, and Action
 	// type Configure methods.
 	resp.DataSourceData = client
 	resp.ResourceData = client
+	resp.ActionData = client
 }
 
 // DataSources defines the data sources implemented in the provider.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-framework/action"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -17,7 +18,8 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ provider.Provider = &aapProvider{}
+	_ provider.Provider            = &aapProvider{}
+	_ provider.ProviderWithActions = &aapProvider{}
 )
 
 // New is a helper function to simplify provider server and testing implementation.
@@ -193,6 +195,13 @@ func (p *aapProvider) Resources(_ context.Context) []func() resource.Resource {
 		NewWorkflowJobResource,
 		NewGroupResource,
 		NewHostResource,
+	}
+}
+
+// Actions defines the actions implemented in the provider.
+func (p *aapProvider) Actions(_ context.Context) []func() action.Action {
+	return []func() action.Action{
+		NewEDAEventStreamAction,
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -171,11 +171,10 @@ func (p *aapProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	client, diags := NewClient(host, authenticator, insecureSkipVerify, timeout)
 	resp.Diagnostics.Append(diags...)
 
-	// Make the http client available during DataSource, Resource, and Action
+	// Make the http client available during DataSource and Resource
 	// type Configure methods.
 	resp.DataSourceData = client
 	resp.ResourceData = client
-	resp.ActionData = client
 }
 
 // DataSources defines the data sources implemented in the provider.

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -595,3 +595,15 @@ func TestConfigure(t *testing.T) {
 		})
 	}
 }
+
+func TestActions(t *testing.T) {
+	p := aapProvider{
+		version: "test",
+	}
+	actions := p.Actions(t.Context())
+	expected := 1
+	actual := len(actions)
+	if expected != actual {
+		t.Errorf("Expected provider.Actions to return %v actions, found %v", expected, actual)
+	}
+}


### PR DESCRIPTION
This PR implements a terraform action `aap_eda_eventstream` that when used with Terraform 1.14 or later (currently in beta) can send payloads to Event-Driven Ansible Event Streams in Ansible Automation Platform. It targets the `dev-preview` branch

- Supports basic authentication with http or https event stream endpoints
- Adds unit tests to cover utility functions, acceptance tests to cover action functionality
- Provider documentation and changelog not included (coming in a separate PR)

See https://github.com/dleehr/tfa-demo/blob/main/ansible/playbook.yml for a playbook that can configure AAP with a EDA and event streams

https://issues.redhat.com/browse/AAP-52752