### PR TITLE
[AAP-54793] 1: Add client readApiEndpoint tests

### DIFF
--- a/internal/provider/client_test.go
+++ b/internal/provider/client_test.go
@@ -10,6 +10,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	apiEndpoint        = "/api/"
+	controllerEndpoint = "/api/controller/"
+	edaEndpoint        = "/api/eda/"
+)
+
 type MockAuthenticator struct {
 }
 
@@ -45,7 +51,7 @@ func TestComputeURLPath(t *testing.T) {
 
 func TestReadApiEndpoint(t *testing.T) {
 	server_24 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/" {
+		if r.URL.Path != apiEndpoint {
 			t.Errorf("Expected to request '/api/', got: %s", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusOK)
@@ -55,13 +61,13 @@ func TestReadApiEndpoint(t *testing.T) {
 
 	server_25 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/api/":
+		case apiEndpoint:
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"apis":{"gateway": "/api/gateway/", "controller": "/api/controller/", "eda": "/api/eda/"}}`)) //nolint:errcheck
-		case "/api/controller/":
+		case controllerEndpoint:
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"current_version": "/api/controller/v2/"}`)) //nolint:errcheck
-		case "/api/eda/":
+		case edaEndpoint:
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"current_version": "http://localhost/api/eda/v1/"}`)) //nolint:errcheck
 		default:
@@ -70,12 +76,12 @@ func TestReadApiEndpoint(t *testing.T) {
 	}))
 	defer server_25.Close()
 
-	failingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	failingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer failingServer.Close()
 
-	badJsonServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	badJsonServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// Write back intentionally invalid JSON
 		w.Write([]byte(`{`)) //nolint:errcheck
 	}))
@@ -83,10 +89,10 @@ func TestReadApiEndpoint(t *testing.T) {
 
 	serverWithMissingControllerEndpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/api/":
+		case apiEndpoint:
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"apis":{"gateway": "/api/gateway/", "controller": "/api/controller/", "eda": "/api/eda/"}}`)) //nolint:errcheck
-		case "/api/controller/":
+		case controllerEndpoint:
 			w.WriteHeader(http.StatusNotFound)
 		default:
 			t.Errorf("Expected to request one of '/api/', '/api/controller/', '/api/eda/', got: %s", r.URL.Path)
@@ -96,10 +102,10 @@ func TestReadApiEndpoint(t *testing.T) {
 
 	serverWithBadControllerJSON := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/api/":
+		case apiEndpoint:
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"apis":{"gateway": "/api/gateway/", "controller": "/api/controller/", "eda": "/api/eda/"}}`)) //nolint:errcheck
-		case "/api/controller/":
+		case controllerEndpoint:
 			// Write back intentionally invalid JSON
 			w.Write([]byte(`{`)) //nolint:errcheck
 		default:
@@ -110,13 +116,13 @@ func TestReadApiEndpoint(t *testing.T) {
 
 	serverWithMissingEDAEndpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/api/":
+		case apiEndpoint:
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"apis":{"gateway": "/api/gateway/", "controller": "/api/controller/", "eda": "/api/eda/"}}`)) //nolint:errcheck
-		case "/api/controller/":
+		case controllerEndpoint:
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"current_version": "/api/controller/v2/"}`)) //nolint:errcheck
-		case "/api/eda/":
+		case edaEndpoint:
 			w.WriteHeader(http.StatusNotFound)
 		default:
 			t.Errorf("Expected to request one of '/api/', '/api/controller/', '/api/eda/', got: %s", r.URL.Path)
@@ -126,12 +132,12 @@ func TestReadApiEndpoint(t *testing.T) {
 
 	serverWithBadEDAJSON := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/api/":
+		case apiEndpoint:
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"apis":{"gateway": "/api/gateway/", "controller": "/api/controller/", "eda": "/api/eda/"}}`)) //nolint:errcheck
-		case "/api/controller/":
+		case controllerEndpoint:
 			w.Write([]byte(`{"current_version": "/api/controller/v2/"}`)) //nolint:errcheck
-		case "/api/eda/":
+		case edaEndpoint:
 			// Write back intentionally invalid JSON
 			w.Write([]byte(`{`)) //nolint:errcheck
 		default:
@@ -142,12 +148,12 @@ func TestReadApiEndpoint(t *testing.T) {
 
 	serverWithInvalidEDAURL := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/api/":
+		case apiEndpoint:
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"apis":{"gateway": "/api/gateway/", "controller": "/api/controller/", "eda": "/api/eda/"}}`)) //nolint:errcheck
-		case "/api/controller/":
+		case controllerEndpoint:
 			w.Write([]byte(`{"current_version": "/api/controller/v2/"}`)) //nolint:errcheck
-		case "/api/eda/":
+		case edaEndpoint:
 			// Write an invalid url
 			w.Write([]byte(`{"current_version": "://localhost/api/eda/v1/"}`)) //nolint:errcheck
 		default:

--- a/internal/provider/client_test.go
+++ b/internal/provider/client_test.go
@@ -262,7 +262,8 @@ func TestReadApiEndpointForEDA(t *testing.T) {
 	}
 }
 
-func executeReadApiEndpointTestCase(t *testing.T, tc readApiEndpointTestCase) {
+func executeReadApiEndpointTestCase(t testing.TB, tc readApiEndpointTestCase) {
+	t.Helper()
 	// readApiEndpoint() is called when creating client
 	client, diags := NewClient(tc.url, &MockAuthenticator{}, true, 0)
 

--- a/internal/provider/client_test.go
+++ b/internal/provider/client_test.go
@@ -12,8 +12,8 @@ import (
 
 const (
 	apiEndpoint        = "/api/"
-	controllerEndpoint = "/api/controller/"  // Base API endpoint for Controller in AAP >= 2.5
-	edaEndpoint        = "/api/eda/"  // Base API endpoint for EDA in AAP >= 2.5
+	controllerEndpoint = "/api/controller/" // Base API endpoint for Controller in AAP >= 2.5
+	edaEndpoint        = "/api/eda/"        // Base API endpoint for EDA in AAP >= 2.5
 )
 
 type MockAuthenticator struct {
@@ -54,6 +54,24 @@ func TestComputeURLPath(t *testing.T) {
 			result := client.computeURLPath(tc.path)
 			assert.Equal(t, expected, result, fmt.Sprintf("expected (%s), got (%s)", expected, result))
 		})
+	}
+}
+
+func executeReadApiEndpointTestCase(t testing.TB, tc readApiEndpointTestCase) {
+	t.Helper()
+	// readApiEndpoint() is called when creating client
+	client, diags := NewClient(tc.url, &MockAuthenticator{}, true, 0)
+
+	assert.Equal(t, tc.expectedControllerPath, client.getApiEndpoint())
+	assert.Equal(t, tc.expectedEDAPath, client.getEdaApiEndpoint())
+
+	if tc.diagsShouldHaveErr != diags.HasError() {
+		t.Errorf(
+			"readApiEndpoint() diagnostic error check failed. Expected: %t, got %t. diags was (%v)",
+			tc.diagsShouldHaveErr,
+			diags.HasError(),
+			diags,
+		)
 	}
 }
 
@@ -259,24 +277,6 @@ func TestReadApiEndpointForEDA(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			executeReadApiEndpointTestCase(t, tc)
 		})
-	}
-}
-
-func executeReadApiEndpointTestCase(t testing.TB, tc readApiEndpointTestCase) {
-	t.Helper()
-	// readApiEndpoint() is called when creating client
-	client, diags := NewClient(tc.url, &MockAuthenticator{}, true, 0)
-
-	assert.Equal(t, tc.expectedControllerPath, client.getApiEndpoint())
-	assert.Equal(t, tc.expectedEDAPath, client.getEdaApiEndpoint())
-
-	if tc.diagsShouldHaveErr != diags.HasError() {
-		t.Errorf(
-			"readApiEndpoint() diagnostic error check failed. Expected: %t, got %t. diags was (%v)",
-			tc.diagsShouldHaveErr,
-			diags.HasError(),
-			diags,
-		)
 	}
 }
 

--- a/internal/provider/client_test.go
+++ b/internal/provider/client_test.go
@@ -12,8 +12,8 @@ import (
 
 const (
 	apiEndpoint        = "/api/"
-	controllerEndpoint = "/api/controller/"
-	edaEndpoint        = "/api/eda/"
+	controllerEndpoint = "/api/controller/"  // Base API endpoint for Controller in AAP >= 2.5
+	edaEndpoint        = "/api/eda/"  // Base API endpoint for EDA in AAP >= 2.5
 )
 
 type MockAuthenticator struct {


### PR DESCRIPTION
This adds a number of test cases to work out the various code paths in the `readApiEndpoint()` function. The tests work by creating multiple http servers that respond with various values for the `/api/`, `/api/controller`, and `/api/eda` endpoints.

Related: AAP-54793