### PR TITLE
fix: .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,40 +1,6 @@
-version: 2
-
-linters-settings:
-  goconst:
-    min-len: 2
-    min-occurrences: 3
-  gocyclo:
-    min-complexity: 15
-  gosec:
-    exclude-rules:
-      - G402
-  govet:
-    settings:
-      printf:
-        funcs:
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-  lll:
-    line-length: 160
-  misspell:
-    locale: US
-  nolintlint:
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
-  revive:
-    rules:
-      - name: unexported-return
-        disabled: true
-      - name: unused-parameter
-  stylecheck:
-    checks: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - dogsled
     - errcheck
@@ -60,18 +26,62 @@ linters:
     - unused
     - whitespace
   settings:
+    goconst:
+      min-len: 2
+      min-occurrences: 3
+    gocyclo:
+      min-complexity: 15
+    gosec:
+      excludes:
+        - G402
+    govet:
+      settings:
+        printf:
+          funcs:
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
     lll:
       line-length: 160
+    misspell:
+      locale: US
+    nolintlint:
+      require-explanation: false
+      require-specific: false
+      allow-unused: false
+    revive:
+      rules:
+        - name: unexported-return
+          disabled: true
+        - name: unused-parameter
+    staticcheck:
+      checks:
+        - all
+        - -ST1000
+        - -ST1003
+        - -ST1016
+        - -ST1020
+        - -ST1021
+        - -ST1022
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 formatters:
   enable:
     - gofmt
     - goimports
-
-issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules: []
-
-
-
-run:
-  timeout: 5m
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/internal/provider/base_utils.go
+++ b/internal/provider/base_utils.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-// IsContextActive checks if the provided context is still active and adds diagnostics if cancelled.
+// IsContextActive checks if the provided context is still active and adds diagnostics if canceled.
 func IsContextActive(ctx context.Context, operationName string, diagnostics *diag.Diagnostics) bool {
 	if ctx.Err() != nil {
 		if diagnostics != nil {

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -89,7 +89,7 @@ func NewClient(host string, authenticator AAPClientAuthenticator, insecureSkipVe
 	}
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify}, //nolint:gosec // User configurable option
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify}, // User configurable option
 	}
 	client.httpClient = &http.Client{Transport: tr, Timeout: time.Duration(timeout) * time.Second}
 


### PR DESCRIPTION
Used:

```
.tools/golangci-lint migrate
```

To correctly migrate the `.golangci.yml` file. This will no longer cause `make lint` to fail:
```
make: *** [makefiles/golangci.mk:21: lint] Error 1
``` 

Adjusted other files to accommodate the new linting.