### PR TITLE
remove debugging log line

### DIFF
--- a/internal/provider/base_eda_datasource.go
+++ b/internal/provider/base_eda_datasource.go
@@ -31,7 +31,6 @@ func NewBaseEdaDataSource(client ProviderHTTPClient, stringDescriptions StringDe
 // entity slug string passed in the constructor.
 func (d *BaseEdaDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, d.MetadataEntitySlug)
-	fmt.Println(resp.TypeName)
 }
 
 // GetBaseAttributes returns the base set of attributes for an EDA data source. This


### PR DESCRIPTION
This log line blows up stdout with a lot of "aap_eda_eventstream" logs. Im guessing this was used in development of #150, but didn't get removed. @davemulford concerns over removing this line?

Example:
```
# go test -v -run TestAccAAPJob ./...
?       github.com/ansible/terraform-provider-aap       [no test files]
=== RUN   TestAccAAPJobAction_basic
aap_eda_eventstream
aap_eda_eventstream
aap_eda_eventstream
aap_eda_eventstream
aap_eda_eventstream
aap_eda_eventstream
aap_eda_eventstream
aap_eda_eventstream
aap_eda_eventstream
````