### PR TITLE
AAP-64680 Replace read-all with specific permissions

### DIFF
--- a/.github/workflows/sonar-checks.yml
+++ b/.github/workflows/sonar-checks.yml
@@ -1,4 +1,4 @@
-name: SonarCube Static Scans (PR)
+name: SonarQube Static Scans (PR)
 
 on:
   workflow_run:

--- a/.github/workflows/sonar-checks.yml
+++ b/.github/workflows/sonar-checks.yml
@@ -7,9 +7,12 @@ on:
     types:
       - completed
 
-permissions: read-all
 jobs:
   sonarcloud:
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: read
     name: SonarQube Static Scans (PR)
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'


### PR DESCRIPTION
AAP-64680 

Moves permissions from workflow-level to job-level to address SonarQube security issue.

Addressing this issue: https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=ansible_terraform-provider-aap&open=AZvk2Tk_rDYPcCTzR7Dk&tab=how_to_fix

  Replaces `permissions: read-all` with specific permissions in the sonar-checks workflow:         
  - `contents: read` - for checkout and scanning
  - `actions: read` - for downloading artifacts
  - `pull-requests: read` - for PR metadata

This issue appears to be identical to the one in receptor which was addressed in Pablo's PR: https://github.com/ansible/receptor/pull/1519