### PR TITLE
fix prompt on launch validation

### DIFF
--- a/internal/provider/job_launch_action_test.go
+++ b/internal/provider/job_launch_action_test.go
@@ -622,12 +622,12 @@ func TestAccAAPJobAction_AllFieldsOnPrompt(t *testing.T) {
 	})
 }
 
-// TestAccAAPJobAction_AllFieldsOnPrompt_MissingRequired tests that a job action with all
-// fields on prompt fails when required fields are not provided.
+// TestAccAAPJobAction_AllFieldsOnPrompt_MissingRequired tests that a job action with
+// required survey fields fails when required fields are not provided.
 func TestAccAAPJobAction_AllFieldsOnPrompt_MissingRequired(t *testing.T) {
-	jobTemplateID := os.Getenv("AAP_TEST_JOB_TEMPLATE_ALL_FIELDS_PROMPT_ID")
+	jobTemplateID := os.Getenv("AAP_TEST_JOB_TEMPLATE_WITH_SURVEY_ID")
 	if jobTemplateID == "" {
-		t.Skip("AAP_TEST_JOB_TEMPLATE_ALL_FIELDS_PROMPT_ID environment variable not set")
+		t.Skip("AAP_TEST_JOB_TEMPLATE_WITH_SURVEY_ID environment variable not set")
 	}
 	randNum, _ := rand.Int(rand.Reader, big.NewInt(50000000))
 	inventoryName := fmt.Sprintf("%s-%d", "tf-acc", randNum.Int64())

--- a/internal/provider/job_resource.go
+++ b/internal/provider/job_resource.go
@@ -56,21 +56,23 @@ type JobAPIModel struct {
 // GET /api/controller/v2/job_templates/<id>/launch/
 // It helps determine if a job_template can be launched.
 type JobLaunchAPIModel struct {
-	AskVariablesOnLaunch            bool `json:"ask_variables_on_launch"`
-	AskTagsOnLaunch                 bool `json:"ask_tags_on_launch"`
-	AskSkipTagsOnLaunch             bool `json:"ask_skip_tags_on_launch"`
-	AskJobTypeOnLaunch              bool `json:"ask_job_type_on_launch"`
-	AskLimitOnLaunch                bool `json:"ask_limit_on_launch"`
-	AskInventoryOnLaunch            bool `json:"ask_inventory_on_launch"`
-	AskCredentialOnLaunch           bool `json:"ask_credential_on_launch"`
-	AskExecutionEnvironmentOnLaunch bool `json:"ask_execution_environment_on_launch"`
-	AskLabelsOnLaunch               bool `json:"ask_labels_on_launch"`
-	AskForksOnLaunch                bool `json:"ask_forks_on_launch"`
-	AskDiffModeOnLaunch             bool `json:"ask_diff_mode_on_launch"`
-	AskVerbosityOnLaunch            bool `json:"ask_verbosity_on_launch"`
-	AskInstanceGroupsOnLaunch       bool `json:"ask_instance_groups_on_launch"`
-	AskTimeoutOnLaunch              bool `json:"ask_timeout_on_launch"`
-	AskJobSliceCountOnLaunch        bool `json:"ask_job_slice_count_on_launch"`
+	AskVariablesOnLaunch            bool     `json:"ask_variables_on_launch"`
+	AskTagsOnLaunch                 bool     `json:"ask_tags_on_launch"`
+	AskSkipTagsOnLaunch             bool     `json:"ask_skip_tags_on_launch"`
+	AskJobTypeOnLaunch              bool     `json:"ask_job_type_on_launch"`
+	AskLimitOnLaunch                bool     `json:"ask_limit_on_launch"`
+	AskInventoryOnLaunch            bool     `json:"ask_inventory_on_launch"`
+	AskCredentialOnLaunch           bool     `json:"ask_credential_on_launch"`
+	AskExecutionEnvironmentOnLaunch bool     `json:"ask_execution_environment_on_launch"`
+	AskLabelsOnLaunch               bool     `json:"ask_labels_on_launch"`
+	AskForksOnLaunch                bool     `json:"ask_forks_on_launch"`
+	AskDiffModeOnLaunch             bool     `json:"ask_diff_mode_on_launch"`
+	AskVerbosityOnLaunch            bool     `json:"ask_verbosity_on_launch"`
+	AskInstanceGroupsOnLaunch       bool     `json:"ask_instance_groups_on_launch"`
+	AskTimeoutOnLaunch              bool     `json:"ask_timeout_on_launch"`
+	AskJobSliceCountOnLaunch        bool     `json:"ask_job_slice_count_on_launch"`
+	SurveyEnabled                   bool     `json:"survey_enabled"`
+	VariablesNeededToStart          []string `json:"variables_needed_to_start"`
 }
 
 // JobLaunchRequestModel represents the request body for POST /job_templates/{id}/launch.
@@ -565,7 +567,7 @@ func (r *JobModel) CanJobBeLaunched(client ProviderHTTPClient) (diags diag.Diagn
 		{launchConfig.AskJobSliceCountOnLaunch, r.JobSliceCount, "job_slice_count"},
 	}
 
-	diags.Append(ValidateLaunchFields(validations, "Job Template")...)
+	diags.Append(ValidateLaunchFields(launchConfig.VariablesNeededToStart, validations, "Job Template")...)
 
 	return diags
 }

--- a/internal/provider/job_resource.go
+++ b/internal/provider/job_resource.go
@@ -73,6 +73,8 @@ type JobLaunchAPIModel struct {
 	AskJobSliceCountOnLaunch        bool     `json:"ask_job_slice_count_on_launch"`
 	SurveyEnabled                   bool     `json:"survey_enabled"`
 	VariablesNeededToStart          []string `json:"variables_needed_to_start"`
+	InventoryNeededToStart          bool     `json:"inventory_needed_to_start"`
+	CredentialNeededToStart         bool     `json:"credential_needed_to_start"`
 }
 
 // JobLaunchRequestModel represents the request body for POST /job_templates/{id}/launch.
@@ -567,7 +569,13 @@ func (r *JobModel) CanJobBeLaunched(client ProviderHTTPClient) (diags diag.Diagn
 		{launchConfig.AskJobSliceCountOnLaunch, r.JobSliceCount, "job_slice_count"},
 	}
 
-	diags.Append(ValidateLaunchFields(launchConfig.VariablesNeededToStart, validations, "Job Template")...)
+	requirements := LaunchRequirements{
+		VariablesNeededToStart:  launchConfig.VariablesNeededToStart,
+		InventoryNeededToStart:  launchConfig.InventoryNeededToStart,
+		CredentialNeededToStart: launchConfig.CredentialNeededToStart,
+	}
+
+	diags.Append(ValidateLaunchFields(requirements, validations, "Job Template", r.ExtraVars)...)
 
 	return diags
 }

--- a/internal/provider/job_resource_test.go
+++ b/internal/provider/job_resource_test.go
@@ -1339,16 +1339,17 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 			model:          JobModel{TemplateID: types.Int64Value(1), Labels: basetypes.NewListValueMust(types.Int64Type, []attr.Value{types.Int64Value(1)})},
 			expectWarnings: true,
 		},
-		// Combined success case
+		// Template fields can be provided when allowed
 		{
-			name: "all required fields provided - no errors",
+			name: "template fields allowed and provided - no errors",
 			launchConfig: JobLaunchAPIModel{
 				AskVariablesOnLaunch:      true,
 				AskLimitOnLaunch:          true,
 				AskInventoryOnLaunch:      true,
 				AskVerbosityOnLaunch:      true,
 				AskInstanceGroupsOnLaunch: true,
-				VariablesNeededToStart:    []string{"extra_vars", "limit", "inventory", "verbosity", "instance_groups"},
+				InventoryNeededToStart:    false,
+				CredentialNeededToStart:   false,
 			},
 			model: JobModel{
 				TemplateID:     types.Int64Value(1),

--- a/internal/provider/job_resource_test.go
+++ b/internal/provider/job_resource_test.go
@@ -1157,11 +1157,26 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 			model:        JobModel{TemplateID: types.Int64Value(1)},
 			expectError:  false,
 		},
-		// extra_vars
+		// ask_on_launch=true does NOT mean field is required
 		{
-			name:         "extra_vars required but not provided",
-			launchConfig: JobLaunchAPIModel{AskVariablesOnLaunch: true, VariablesNeededToStart: []string{"extra_vars"}},
-			model:        JobModel{TemplateID: types.Int64Value(1), ExtraVars: customtypes.NewAAPCustomStringNull()},
+			name: "ask_on_launch true but field not required - no error",
+			launchConfig: JobLaunchAPIModel{
+				AskInventoryOnLaunch:    true,
+				InventoryNeededToStart:  false,
+				CredentialNeededToStart: false,
+			},
+			model: JobModel{
+				TemplateID:  types.Int64Value(1),
+				InventoryID: types.Int64Null(),
+				Credentials: types.ListNull(types.Int64Type),
+			},
+			expectError: false,
+		},
+		// Survey variables (in extra_vars)
+		{
+			name:         "survey variable required but not provided in extra_vars",
+			launchConfig: JobLaunchAPIModel{AskVariablesOnLaunch: true, VariablesNeededToStart: []string{"my_survey_var"}},
+			model:        JobModel{TemplateID: types.Int64Value(1), ExtraVars: customtypes.NewAAPCustomStringValue(`{}`)},
 			expectError:  true,
 		},
 		{
@@ -1173,7 +1188,7 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 		// inventory_id
 		{
 			name:         "inventory_id required but not provided",
-			launchConfig: JobLaunchAPIModel{AskInventoryOnLaunch: true, VariablesNeededToStart: []string{"inventory"}},
+			launchConfig: JobLaunchAPIModel{AskInventoryOnLaunch: true, InventoryNeededToStart: true},
 			model:        JobModel{TemplateID: types.Int64Value(1), InventoryID: types.Int64Null()},
 			expectError:  true,
 		},
@@ -1183,140 +1198,38 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 			model:          JobModel{TemplateID: types.Int64Value(1), InventoryID: types.Int64Value(10)},
 			expectWarnings: true,
 		},
-		// limit
-		{
-			name:         "limit required but not provided",
-			launchConfig: JobLaunchAPIModel{AskLimitOnLaunch: true, VariablesNeededToStart: []string{"limit"}},
-			model:        JobModel{TemplateID: types.Int64Value(1), Limit: customtypes.NewAAPCustomStringNull()},
-			expectError:  true,
-		},
+		// limit (can only be optional at template level, never required)
 		{
 			name:           "limit provided but not expected - warning",
 			launchConfig:   JobLaunchAPIModel{AskLimitOnLaunch: false},
 			model:          JobModel{TemplateID: types.Int64Value(1), Limit: customtypes.NewAAPCustomStringValue("all")},
 			expectWarnings: true,
 		},
-		// job_tags
-		{
-			name:         "job_tags required but not provided",
-			launchConfig: JobLaunchAPIModel{AskTagsOnLaunch: true, VariablesNeededToStart: []string{"job_tags"}},
-			model:        JobModel{TemplateID: types.Int64Value(1), JobTags: customtypes.NewAAPCustomStringNull()},
-			expectError:  true,
-		},
+		// job_tags (can only be optional at template level, never required)
 		{
 			name:           "job_tags provided but not expected - warning",
 			launchConfig:   JobLaunchAPIModel{AskTagsOnLaunch: false},
 			model:          JobModel{TemplateID: types.Int64Value(1), JobTags: customtypes.NewAAPCustomStringValue("deploy")},
 			expectWarnings: true,
 		},
-		// skip_tags
-		{
-			name:         "skip_tags required but not provided",
-			launchConfig: JobLaunchAPIModel{AskSkipTagsOnLaunch: true, VariablesNeededToStart: []string{"skip_tags"}},
-			model:        JobModel{TemplateID: types.Int64Value(1), SkipTags: customtypes.NewAAPCustomStringNull()},
-			expectError:  true,
-		},
+		// skip_tags (can only be optional at template level, never required)
 		{
 			name:           "skip_tags provided but not expected - warning",
 			launchConfig:   JobLaunchAPIModel{AskSkipTagsOnLaunch: false},
 			model:          JobModel{TemplateID: types.Int64Value(1), SkipTags: customtypes.NewAAPCustomStringValue("debug")},
 			expectWarnings: true,
 		},
-		// diff_mode
-		{
-			name:         "diff_mode required but not provided",
-			launchConfig: JobLaunchAPIModel{AskDiffModeOnLaunch: true, VariablesNeededToStart: []string{"diff_mode"}},
-			model:        JobModel{TemplateID: types.Int64Value(1), DiffMode: types.BoolNull()},
-			expectError:  true,
-		},
+		// diff_mode (can only be optional at template level, never required)
 		{
 			name:           "diff_mode provided but not expected - warning",
 			launchConfig:   JobLaunchAPIModel{AskDiffModeOnLaunch: false},
 			model:          JobModel{TemplateID: types.Int64Value(1), DiffMode: types.BoolValue(true)},
 			expectWarnings: true,
 		},
-		// verbosity
-		{
-			name:         "verbosity required but not provided",
-			launchConfig: JobLaunchAPIModel{AskVerbosityOnLaunch: true, VariablesNeededToStart: []string{"verbosity"}},
-			model:        JobModel{TemplateID: types.Int64Value(1), Verbosity: types.Int64Null()},
-			expectError:  true,
-		},
-		{
-			name:           "verbosity provided but not expected - warning",
-			launchConfig:   JobLaunchAPIModel{AskVerbosityOnLaunch: false},
-			model:          JobModel{TemplateID: types.Int64Value(1), Verbosity: types.Int64Value(3)},
-			expectWarnings: true,
-		},
-		// forks
-		{
-			name:         "forks required but not provided",
-			launchConfig: JobLaunchAPIModel{AskForksOnLaunch: true, VariablesNeededToStart: []string{"forks"}},
-			model:        JobModel{TemplateID: types.Int64Value(1), Forks: types.Int64Null()},
-			expectError:  true,
-		},
-		{
-			name:           "forks provided but not expected - warning",
-			launchConfig:   JobLaunchAPIModel{AskForksOnLaunch: false},
-			model:          JobModel{TemplateID: types.Int64Value(1), Forks: types.Int64Value(10)},
-			expectWarnings: true,
-		},
-		// timeout
-		{
-			name:         "timeout required but not provided",
-			launchConfig: JobLaunchAPIModel{AskTimeoutOnLaunch: true, VariablesNeededToStart: []string{"timeout"}},
-			model:        JobModel{TemplateID: types.Int64Value(1), Timeout: types.Int64Null()},
-			expectError:  true,
-		},
-		{
-			name:           "timeout provided but not expected - warning",
-			launchConfig:   JobLaunchAPIModel{AskTimeoutOnLaunch: false},
-			model:          JobModel{TemplateID: types.Int64Value(1), Timeout: types.Int64Value(3600)},
-			expectWarnings: true,
-		},
-		// job_slice_count
-		{
-			name:         "job_slice_count required but not provided",
-			launchConfig: JobLaunchAPIModel{AskJobSliceCountOnLaunch: true, VariablesNeededToStart: []string{"job_slice_count"}},
-			model:        JobModel{TemplateID: types.Int64Value(1), JobSliceCount: types.Int64Null()},
-			expectError:  true,
-		},
-		{
-			name:           "job_slice_count provided but not expected - warning",
-			launchConfig:   JobLaunchAPIModel{AskJobSliceCountOnLaunch: false},
-			model:          JobModel{TemplateID: types.Int64Value(1), JobSliceCount: types.Int64Value(4)},
-			expectWarnings: true,
-		},
-		// execution_environment
-		{
-			name:         "execution_environment required but not provided",
-			launchConfig: JobLaunchAPIModel{AskExecutionEnvironmentOnLaunch: true, VariablesNeededToStart: []string{"execution_environment"}},
-			model:        JobModel{TemplateID: types.Int64Value(1), ExecutionEnvironmentID: types.Int64Null()},
-			expectError:  true,
-		},
-		{
-			name:           "execution_environment provided but not expected - warning",
-			launchConfig:   JobLaunchAPIModel{AskExecutionEnvironmentOnLaunch: false},
-			model:          JobModel{TemplateID: types.Int64Value(1), ExecutionEnvironmentID: types.Int64Value(5)},
-			expectWarnings: true,
-		},
-		// instance_groups
-		{
-			name:         "instance_groups required but not provided",
-			launchConfig: JobLaunchAPIModel{AskInstanceGroupsOnLaunch: true, VariablesNeededToStart: []string{"instance_groups"}},
-			model:        JobModel{TemplateID: types.Int64Value(1), InstanceGroups: types.ListNull(types.Int64Type)},
-			expectError:  true,
-		},
-		{
-			name:           "instance_groups provided but not expected - warning",
-			launchConfig:   JobLaunchAPIModel{AskInstanceGroupsOnLaunch: false},
-			model:          JobModel{TemplateID: types.Int64Value(1), InstanceGroups: basetypes.NewListValueMust(types.Int64Type, []attr.Value{types.Int64Value(5)})},
-			expectWarnings: true,
-		},
 		// credentials
 		{
 			name:         "credentials required but not provided",
-			launchConfig: JobLaunchAPIModel{AskCredentialOnLaunch: true, VariablesNeededToStart: []string{"credential"}},
+			launchConfig: JobLaunchAPIModel{AskCredentialOnLaunch: true, CredentialNeededToStart: true},
 			model:        JobModel{TemplateID: types.Int64Value(1), Credentials: types.ListNull(types.Int64Type)},
 			expectError:  true,
 		},
@@ -1326,13 +1239,7 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 			model:          JobModel{TemplateID: types.Int64Value(1), Credentials: basetypes.NewListValueMust(types.Int64Type, []attr.Value{types.Int64Value(1)})},
 			expectWarnings: true,
 		},
-		// labels
-		{
-			name:         "labels required but not provided",
-			launchConfig: JobLaunchAPIModel{AskLabelsOnLaunch: true, VariablesNeededToStart: []string{"labels"}},
-			model:        JobModel{TemplateID: types.Int64Value(1), Labels: types.ListNull(types.Int64Type)},
-			expectError:  true,
-		},
+		// labels (can only be optional at template level, never required)
 		{
 			name:           "labels provided but not expected - warning",
 			launchConfig:   JobLaunchAPIModel{AskLabelsOnLaunch: false},

--- a/internal/provider/job_resource_test.go
+++ b/internal/provider/job_resource_test.go
@@ -862,12 +862,12 @@ func TestAccAAPJob_AllFieldsOnPrompt(t *testing.T) {
 	})
 }
 
-// TestAccAAPJob_AllFieldsOnPrompt_MissingRequired tests that a job resource with all
-// fields on prompt fails when required fields are not provided.
+// TestAccAAPJob_AllFieldsOnPrompt_MissingRequired tests that a job resource with
+// required survey fields fails when required fields are not provided.
 func TestAccAAPJob_AllFieldsOnPrompt_MissingRequired(t *testing.T) {
-	jobTemplateID := os.Getenv("AAP_TEST_JOB_TEMPLATE_ALL_FIELDS_PROMPT_ID")
+	jobTemplateID := os.Getenv("AAP_TEST_JOB_TEMPLATE_WITH_SURVEY_ID")
 	if jobTemplateID == "" {
-		t.Skip("AAP_TEST_JOB_TEMPLATE_ALL_FIELDS_PROMPT_ID environment variable not set")
+		t.Skip("AAP_TEST_JOB_TEMPLATE_WITH_SURVEY_ID environment variable not set")
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -1160,7 +1160,7 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 		// extra_vars
 		{
 			name:         "extra_vars required but not provided",
-			launchConfig: JobLaunchAPIModel{AskVariablesOnLaunch: true},
+			launchConfig: JobLaunchAPIModel{AskVariablesOnLaunch: true, VariablesNeededToStart: []string{"extra_vars"}},
 			model:        JobModel{TemplateID: types.Int64Value(1), ExtraVars: customtypes.NewAAPCustomStringNull()},
 			expectError:  true,
 		},
@@ -1173,7 +1173,7 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 		// inventory_id
 		{
 			name:         "inventory_id required but not provided",
-			launchConfig: JobLaunchAPIModel{AskInventoryOnLaunch: true},
+			launchConfig: JobLaunchAPIModel{AskInventoryOnLaunch: true, VariablesNeededToStart: []string{"inventory"}},
 			model:        JobModel{TemplateID: types.Int64Value(1), InventoryID: types.Int64Null()},
 			expectError:  true,
 		},
@@ -1186,7 +1186,7 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 		// limit
 		{
 			name:         "limit required but not provided",
-			launchConfig: JobLaunchAPIModel{AskLimitOnLaunch: true},
+			launchConfig: JobLaunchAPIModel{AskLimitOnLaunch: true, VariablesNeededToStart: []string{"limit"}},
 			model:        JobModel{TemplateID: types.Int64Value(1), Limit: customtypes.NewAAPCustomStringNull()},
 			expectError:  true,
 		},
@@ -1199,7 +1199,7 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 		// job_tags
 		{
 			name:         "job_tags required but not provided",
-			launchConfig: JobLaunchAPIModel{AskTagsOnLaunch: true},
+			launchConfig: JobLaunchAPIModel{AskTagsOnLaunch: true, VariablesNeededToStart: []string{"job_tags"}},
 			model:        JobModel{TemplateID: types.Int64Value(1), JobTags: customtypes.NewAAPCustomStringNull()},
 			expectError:  true,
 		},
@@ -1212,7 +1212,7 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 		// skip_tags
 		{
 			name:         "skip_tags required but not provided",
-			launchConfig: JobLaunchAPIModel{AskSkipTagsOnLaunch: true},
+			launchConfig: JobLaunchAPIModel{AskSkipTagsOnLaunch: true, VariablesNeededToStart: []string{"skip_tags"}},
 			model:        JobModel{TemplateID: types.Int64Value(1), SkipTags: customtypes.NewAAPCustomStringNull()},
 			expectError:  true,
 		},
@@ -1225,7 +1225,7 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 		// diff_mode
 		{
 			name:         "diff_mode required but not provided",
-			launchConfig: JobLaunchAPIModel{AskDiffModeOnLaunch: true},
+			launchConfig: JobLaunchAPIModel{AskDiffModeOnLaunch: true, VariablesNeededToStart: []string{"diff_mode"}},
 			model:        JobModel{TemplateID: types.Int64Value(1), DiffMode: types.BoolNull()},
 			expectError:  true,
 		},
@@ -1238,7 +1238,7 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 		// verbosity
 		{
 			name:         "verbosity required but not provided",
-			launchConfig: JobLaunchAPIModel{AskVerbosityOnLaunch: true},
+			launchConfig: JobLaunchAPIModel{AskVerbosityOnLaunch: true, VariablesNeededToStart: []string{"verbosity"}},
 			model:        JobModel{TemplateID: types.Int64Value(1), Verbosity: types.Int64Null()},
 			expectError:  true,
 		},
@@ -1251,7 +1251,7 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 		// forks
 		{
 			name:         "forks required but not provided",
-			launchConfig: JobLaunchAPIModel{AskForksOnLaunch: true},
+			launchConfig: JobLaunchAPIModel{AskForksOnLaunch: true, VariablesNeededToStart: []string{"forks"}},
 			model:        JobModel{TemplateID: types.Int64Value(1), Forks: types.Int64Null()},
 			expectError:  true,
 		},
@@ -1264,7 +1264,7 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 		// timeout
 		{
 			name:         "timeout required but not provided",
-			launchConfig: JobLaunchAPIModel{AskTimeoutOnLaunch: true},
+			launchConfig: JobLaunchAPIModel{AskTimeoutOnLaunch: true, VariablesNeededToStart: []string{"timeout"}},
 			model:        JobModel{TemplateID: types.Int64Value(1), Timeout: types.Int64Null()},
 			expectError:  true,
 		},
@@ -1277,7 +1277,7 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 		// job_slice_count
 		{
 			name:         "job_slice_count required but not provided",
-			launchConfig: JobLaunchAPIModel{AskJobSliceCountOnLaunch: true},
+			launchConfig: JobLaunchAPIModel{AskJobSliceCountOnLaunch: true, VariablesNeededToStart: []string{"job_slice_count"}},
 			model:        JobModel{TemplateID: types.Int64Value(1), JobSliceCount: types.Int64Null()},
 			expectError:  true,
 		},
@@ -1290,7 +1290,7 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 		// execution_environment
 		{
 			name:         "execution_environment required but not provided",
-			launchConfig: JobLaunchAPIModel{AskExecutionEnvironmentOnLaunch: true},
+			launchConfig: JobLaunchAPIModel{AskExecutionEnvironmentOnLaunch: true, VariablesNeededToStart: []string{"execution_environment"}},
 			model:        JobModel{TemplateID: types.Int64Value(1), ExecutionEnvironmentID: types.Int64Null()},
 			expectError:  true,
 		},
@@ -1303,7 +1303,7 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 		// instance_groups
 		{
 			name:         "instance_groups required but not provided",
-			launchConfig: JobLaunchAPIModel{AskInstanceGroupsOnLaunch: true},
+			launchConfig: JobLaunchAPIModel{AskInstanceGroupsOnLaunch: true, VariablesNeededToStart: []string{"instance_groups"}},
 			model:        JobModel{TemplateID: types.Int64Value(1), InstanceGroups: types.ListNull(types.Int64Type)},
 			expectError:  true,
 		},
@@ -1316,7 +1316,7 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 		// credentials
 		{
 			name:         "credentials required but not provided",
-			launchConfig: JobLaunchAPIModel{AskCredentialOnLaunch: true},
+			launchConfig: JobLaunchAPIModel{AskCredentialOnLaunch: true, VariablesNeededToStart: []string{"credential"}},
 			model:        JobModel{TemplateID: types.Int64Value(1), Credentials: types.ListNull(types.Int64Type)},
 			expectError:  true,
 		},
@@ -1329,7 +1329,7 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 		// labels
 		{
 			name:         "labels required but not provided",
-			launchConfig: JobLaunchAPIModel{AskLabelsOnLaunch: true},
+			launchConfig: JobLaunchAPIModel{AskLabelsOnLaunch: true, VariablesNeededToStart: []string{"labels"}},
 			model:        JobModel{TemplateID: types.Int64Value(1), Labels: types.ListNull(types.Int64Type)},
 			expectError:  true,
 		},
@@ -1348,6 +1348,7 @@ func TestJobModelCanJobBeLaunched(t *testing.T) {
 				AskInventoryOnLaunch:      true,
 				AskVerbosityOnLaunch:      true,
 				AskInstanceGroupsOnLaunch: true,
+				VariablesNeededToStart:    []string{"extra_vars", "limit", "inventory", "verbosity", "instance_groups"},
 			},
 			model: JobModel{
 				TemplateID:     types.Int64Value(1),
@@ -1422,7 +1423,8 @@ func TestJobModelLaunchJob(t *testing.T) {
 				ExtraVars:  customtypes.NewAAPCustomStringNull(),
 			},
 			launchConfig: JobLaunchAPIModel{
-				AskVariablesOnLaunch: true, // extra_vars required but not provided
+				AskVariablesOnLaunch:   true,
+				VariablesNeededToStart: []string{"extra_vars"}, // extra_vars required but not provided
 			},
 			expectError:  true,
 			skipPostMock: true,

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -127,6 +127,20 @@ func ConvertListToInt64Slice(list types.List) []int64 {
 	return result
 }
 
+// terraformToAPIFieldName maps Terraform schema field names to AAP API field names.
+var terraformToAPIFieldName = map[string]string{
+	"inventory_id": "inventory",
+	"credentials":  "credential",
+}
+
+// getAPIFieldName converts a Terraform field name to the corresponding AAP API field name.
+func getAPIFieldName(terraformFieldName string) string {
+	if apiName, ok := terraformToAPIFieldName[terraformFieldName]; ok {
+		return apiName
+	}
+	return terraformFieldName
+}
+
 // LaunchFieldValidation represents a single field validation for launch-time parameters.
 type LaunchFieldValidation struct {
 	AskOnLaunch bool
@@ -136,12 +150,15 @@ type LaunchFieldValidation struct {
 
 // ValidateLaunchFields validates that required fields are provided and warns about ignored fields.
 // Used by both Job and WorkflowJob launch validation.
-func ValidateLaunchFields(validations []LaunchFieldValidation, templateType string) diag.Diagnostics {
+func ValidateLaunchFields(variablesNeededToStart []string, validations []LaunchFieldValidation, templateType string) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	for _, v := range validations {
 		isNullOrUnknown := v.Value.IsNull() || v.Value.IsUnknown()
-		if v.AskOnLaunch && isNullOrUnknown {
+		apiFieldName := getAPIFieldName(v.FieldName)
+		isRequired := slices.Contains(variablesNeededToStart, apiFieldName)
+
+		if isRequired && isNullOrUnknown {
 			diags.AddError(
 				"Missing required field",
 				fmt.Sprintf("%s requires '%s' to be provided at launch", templateType, v.FieldName),

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -147,14 +147,9 @@ func extractExtraVarsString(extraVarsValue attr.Value) string {
 		return ""
 	}
 
-	switch v := extraVarsValue.(type) {
-	case types.String:
-		return v.ValueString()
-	default:
-		// For customtypes.AAPCustomStringValue and other types with ValueString method
-		if stringer, ok := extraVarsValue.(interface{ ValueString() string }); ok {
-			return stringer.ValueString()
-		}
+	// Handle types.String and customtypes.AAPCustomStringValue via ValueString() interface
+	if stringer, ok := extraVarsValue.(interface{ ValueString() string }); ok {
+		return stringer.ValueString()
 	}
 	return ""
 }

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -148,15 +148,28 @@ type LaunchFieldValidation struct {
 	FieldName   string
 }
 
+// LaunchRequirements contains fields from AAP's /launch/ endpoint that indicate what's required.
+type LaunchRequirements struct {
+	VariablesNeededToStart  []string
+	InventoryNeededToStart  bool
+	CredentialNeededToStart bool
+}
+
 // ValidateLaunchFields validates that required fields are provided and warns about ignored fields.
 // Used by both Job and WorkflowJob launch validation.
-func ValidateLaunchFields(variablesNeededToStart []string, validations []LaunchFieldValidation, templateType string) diag.Diagnostics {
+func ValidateLaunchFields(requirements LaunchRequirements, validations []LaunchFieldValidation, templateType string, extraVarsValue attr.Value) diag.Diagnostics {
 	var diags diag.Diagnostics
 
+	// Validate template fields using explicit boolean flags
 	for _, v := range validations {
 		isNullOrUnknown := v.Value.IsNull() || v.Value.IsUnknown()
-		apiFieldName := getAPIFieldName(v.FieldName)
-		isRequired := slices.Contains(variablesNeededToStart, apiFieldName)
+
+		isRequired := false
+		if v.FieldName == "inventory_id" && requirements.InventoryNeededToStart {
+			isRequired = true
+		} else if v.FieldName == "credentials" && requirements.CredentialNeededToStart {
+			isRequired = true
+		}
 
 		if isRequired && isNullOrUnknown {
 			diags.AddError(
@@ -164,11 +177,56 @@ func ValidateLaunchFields(variablesNeededToStart []string, validations []LaunchF
 				fmt.Sprintf("%s requires '%s' to be provided at launch", templateType, v.FieldName),
 			)
 		}
+
 		if !v.AskOnLaunch && !isNullOrUnknown {
 			diags.AddWarning(
 				"Field will be ignored",
 				fmt.Sprintf("'%s' is provided but the %s does not allow it to be specified at launch", v.FieldName, templateType),
 			)
+		}
+	}
+
+	// Validate survey variables (variables_needed_to_start contains required survey variable names)
+	if len(requirements.VariablesNeededToStart) > 0 {
+		// Parse extra_vars JSON to check if required survey variables are provided
+		var extraVarsMap map[string]interface{}
+		extraVarsStr := ""
+
+		// Extract extra_vars string value
+		if !extraVarsValue.IsNull() && !extraVarsValue.IsUnknown() {
+			// Try to get string value from different possible types
+			switch v := extraVarsValue.(type) {
+			case types.String:
+				extraVarsStr = v.ValueString()
+			default:
+				// For customtypes.AAPCustomStringValue and other types with ValueString method
+				if stringer, ok := extraVarsValue.(interface{ ValueString() string }); ok {
+					extraVarsStr = stringer.ValueString()
+				}
+			}
+		}
+
+		// Parse extra_vars if provided
+		if extraVarsStr != "" {
+			if err := json.Unmarshal([]byte(extraVarsStr), &extraVarsMap); err != nil {
+				// If we can't parse extra_vars, we can't validate survey variables
+				diags.AddWarning(
+					"Unable to validate required survey variables",
+					fmt.Sprintf("Could not parse extra_vars as JSON: %s. Survey variable validation will be performed by AAP.", err.Error()),
+				)
+				extraVarsMap = nil
+			}
+		}
+
+		// Check each required survey variable
+		for _, varName := range requirements.VariablesNeededToStart {
+			_, exists := extraVarsMap[varName]
+			if !exists {
+				diags.AddError(
+					"Missing required field",
+					fmt.Sprintf("%s requires survey variable '%s' to be provided in extra_vars", templateType, varName),
+				)
+			}
 		}
 	}
 

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -127,20 +127,6 @@ func ConvertListToInt64Slice(list types.List) []int64 {
 	return result
 }
 
-// terraformToAPIFieldName maps Terraform schema field names to AAP API field names.
-var terraformToAPIFieldName = map[string]string{
-	"inventory_id": "inventory",
-	"credentials":  "credential",
-}
-
-// getAPIFieldName converts a Terraform field name to the corresponding AAP API field name.
-func getAPIFieldName(terraformFieldName string) string {
-	if apiName, ok := terraformToAPIFieldName[terraformFieldName]; ok {
-		return apiName
-	}
-	return terraformFieldName
-}
-
 // LaunchFieldValidation represents a single field validation for launch-time parameters.
 type LaunchFieldValidation struct {
 	AskOnLaunch bool
@@ -155,21 +141,73 @@ type LaunchRequirements struct {
 	CredentialNeededToStart bool
 }
 
+// extractExtraVarsString extracts the string value from extra_vars attr.Value.
+func extractExtraVarsString(extraVarsValue attr.Value) string {
+	if extraVarsValue.IsNull() || extraVarsValue.IsUnknown() {
+		return ""
+	}
+
+	switch v := extraVarsValue.(type) {
+	case types.String:
+		return v.ValueString()
+	default:
+		// For customtypes.AAPCustomStringValue and other types with ValueString method
+		if stringer, ok := extraVarsValue.(interface{ ValueString() string }); ok {
+			return stringer.ValueString()
+		}
+	}
+	return ""
+}
+
+// validateSurveyVariables validates that required survey variables are provided in extra_vars.
+func validateSurveyVariables(requirements LaunchRequirements, extraVarsValue attr.Value, templateType string) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if len(requirements.VariablesNeededToStart) == 0 {
+		return diags
+	}
+
+	extraVarsStr := extractExtraVarsString(extraVarsValue)
+	var extraVarsMap map[string]interface{}
+
+	if extraVarsStr != "" {
+		if err := json.Unmarshal([]byte(extraVarsStr), &extraVarsMap); err != nil {
+			diags.AddWarning(
+				"Unable to validate required survey variables",
+				fmt.Sprintf("Could not parse extra_vars as JSON: %s. Survey variable validation will be performed by AAP.", err.Error()),
+			)
+			return diags
+		}
+	}
+
+	for _, varName := range requirements.VariablesNeededToStart {
+		if _, exists := extraVarsMap[varName]; !exists {
+			diags.AddError(
+				"Missing required field",
+				fmt.Sprintf("%s requires survey variable '%s' to be provided in extra_vars", templateType, varName),
+			)
+		}
+	}
+
+	return diags
+}
+
 // ValidateLaunchFields validates that required fields are provided and warns about ignored fields.
 // Used by both Job and WorkflowJob launch validation.
-func ValidateLaunchFields(requirements LaunchRequirements, validations []LaunchFieldValidation, templateType string, extraVarsValue attr.Value) diag.Diagnostics {
+func ValidateLaunchFields(
+	requirements LaunchRequirements,
+	validations []LaunchFieldValidation,
+	templateType string,
+	extraVarsValue attr.Value,
+) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Validate template fields using explicit boolean flags
 	for _, v := range validations {
 		isNullOrUnknown := v.Value.IsNull() || v.Value.IsUnknown()
 
-		isRequired := false
-		if v.FieldName == "inventory_id" && requirements.InventoryNeededToStart {
-			isRequired = true
-		} else if v.FieldName == "credentials" && requirements.CredentialNeededToStart {
-			isRequired = true
-		}
+		isRequired := (v.FieldName == "inventory_id" && requirements.InventoryNeededToStart) ||
+			(v.FieldName == "credentials" && requirements.CredentialNeededToStart)
 
 		if isRequired && isNullOrUnknown {
 			diags.AddError(
@@ -186,49 +224,8 @@ func ValidateLaunchFields(requirements LaunchRequirements, validations []LaunchF
 		}
 	}
 
-	// Validate survey variables (variables_needed_to_start contains required survey variable names)
-	if len(requirements.VariablesNeededToStart) > 0 {
-		// Parse extra_vars JSON to check if required survey variables are provided
-		var extraVarsMap map[string]interface{}
-		extraVarsStr := ""
-
-		// Extract extra_vars string value
-		if !extraVarsValue.IsNull() && !extraVarsValue.IsUnknown() {
-			// Try to get string value from different possible types
-			switch v := extraVarsValue.(type) {
-			case types.String:
-				extraVarsStr = v.ValueString()
-			default:
-				// For customtypes.AAPCustomStringValue and other types with ValueString method
-				if stringer, ok := extraVarsValue.(interface{ ValueString() string }); ok {
-					extraVarsStr = stringer.ValueString()
-				}
-			}
-		}
-
-		// Parse extra_vars if provided
-		if extraVarsStr != "" {
-			if err := json.Unmarshal([]byte(extraVarsStr), &extraVarsMap); err != nil {
-				// If we can't parse extra_vars, we can't validate survey variables
-				diags.AddWarning(
-					"Unable to validate required survey variables",
-					fmt.Sprintf("Could not parse extra_vars as JSON: %s. Survey variable validation will be performed by AAP.", err.Error()),
-				)
-				extraVarsMap = nil
-			}
-		}
-
-		// Check each required survey variable
-		for _, varName := range requirements.VariablesNeededToStart {
-			_, exists := extraVarsMap[varName]
-			if !exists {
-				diags.AddError(
-					"Missing required field",
-					fmt.Sprintf("%s requires survey variable '%s' to be provided in extra_vars", templateType, varName),
-				)
-			}
-		}
-	}
+	// Validate survey variables
+	diags.Append(validateSurveyVariables(requirements, extraVarsValue, templateType)...)
 
 	return diags
 }

--- a/internal/provider/utils_test.go
+++ b/internal/provider/utils_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ansible/terraform-provider-aap/internal/provider/customtypes"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -464,6 +465,39 @@ func TestExtractExtraVarsString(t *testing.T) {
 	}
 }
 
+// assertDiagnosticCount checks that the number of errors and warnings match expectations.
+func assertDiagnosticCount(t *testing.T, diags diag.Diagnostics, expectErrors, expectWarnings int) {
+	t.Helper()
+	if len(diags.Errors()) != expectErrors {
+		t.Errorf("Expected %d errors, but got %d: %v", expectErrors, len(diags.Errors()), diags.Errors())
+	}
+	if len(diags.Warnings()) != expectWarnings {
+		t.Errorf("Expected %d warnings, but got %d: %v", expectWarnings, len(diags.Warnings()), diags.Warnings())
+	}
+}
+
+// assertDiagnosticContains checks that diagnostics contain expected text.
+func assertDiagnosticContains(t *testing.T, diags diag.Diagnostics, errorContains, warningContains string) {
+	t.Helper()
+	if errorContains != "" {
+		assertDiagnosticListContains(t, diags.Errors(), errorContains, "error")
+	}
+	if warningContains != "" {
+		assertDiagnosticListContains(t, diags.Warnings(), warningContains, "warning")
+	}
+}
+
+// assertDiagnosticListContains checks if any diagnostic in the list contains the expected text.
+func assertDiagnosticListContains(t *testing.T, diagList []diag.Diagnostic, expectedText, diagType string) {
+	t.Helper()
+	for _, d := range diagList {
+		if regexp.MustCompile(expectedText).MatchString(d.Detail()) {
+			return
+		}
+	}
+	t.Errorf("Expected %s to contain %q, but got: %v", diagType, expectedText, diagList)
+}
+
 func TestValidateSurveyVariables(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -533,40 +567,8 @@ func TestValidateSurveyVariables(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			diags := validateSurveyVariables(test.requirements, test.extraVarsValue, test.templateType)
-
-			if len(diags.Errors()) != test.expectErrors {
-				t.Errorf("Expected %d errors, but got %d: %v", test.expectErrors, len(diags.Errors()), diags.Errors())
-			}
-
-			if len(diags.Warnings()) != test.expectWarnings {
-				t.Errorf("Expected %d warnings, but got %d: %v", test.expectWarnings, len(diags.Warnings()), diags.Warnings())
-			}
-
-			if test.errorContains != "" {
-				found := false
-				for _, err := range diags.Errors() {
-					if regexp.MustCompile(test.errorContains).MatchString(err.Detail()) {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("Expected error to contain %q, but got: %v", test.errorContains, diags.Errors())
-				}
-			}
-
-			if test.warningContains != "" {
-				found := false
-				for _, warn := range diags.Warnings() {
-					if regexp.MustCompile(test.warningContains).MatchString(warn.Detail()) {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("Expected warning to contain %q, but got: %v", test.warningContains, diags.Warnings())
-				}
-			}
+			assertDiagnosticCount(t, diags, test.expectErrors, test.expectWarnings)
+			assertDiagnosticContains(t, diags, test.errorContains, test.warningContains)
 		})
 	}
 }

--- a/internal/provider/utils_test.go
+++ b/internal/provider/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/ansible/terraform-provider-aap/internal/provider/customtypes"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -419,6 +420,151 @@ func TestConvertListToInt64Slice(t *testing.T) {
 			for i, expected := range test.expected {
 				if result[i] != expected {
 					t.Errorf("At index %d: expected %d, but got %d", i, expected, result[i])
+				}
+			}
+		})
+	}
+}
+
+func TestExtractExtraVarsString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    attr.Value
+		expected string
+	}{
+		{
+			name:     "null value",
+			input:    types.StringNull(),
+			expected: "",
+		},
+		{
+			name:     "unknown value",
+			input:    types.StringUnknown(),
+			expected: "",
+		},
+		{
+			name:     "types.String with value",
+			input:    types.StringValue(`{"key": "value"}`),
+			expected: `{"key": "value"}`,
+		},
+		{
+			name:     "customtypes.AAPCustomStringValue with value",
+			input:    customtypes.NewAAPCustomStringValue(`{"survey_var": "test"}`),
+			expected: `{"survey_var": "test"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := extractExtraVarsString(test.input)
+			if result != test.expected {
+				t.Errorf("Expected %q, but got %q", test.expected, result)
+			}
+		})
+	}
+}
+
+func TestValidateSurveyVariables(t *testing.T) {
+	tests := []struct {
+		name            string
+		requirements    LaunchRequirements
+		extraVarsValue  attr.Value
+		templateType    string
+		expectErrors    int
+		expectWarnings  int
+		errorContains   string
+		warningContains string
+	}{
+		{
+			name: "no variables needed",
+			requirements: LaunchRequirements{
+				VariablesNeededToStart: []string{},
+			},
+			extraVarsValue: types.StringValue(`{}`),
+			templateType:   "Job Template",
+			expectErrors:   0,
+			expectWarnings: 0,
+		},
+		{
+			name: "all required variables provided",
+			requirements: LaunchRequirements{
+				VariablesNeededToStart: []string{"survey_var1", "survey_var2"},
+			},
+			extraVarsValue: types.StringValue(`{"survey_var1": "value1", "survey_var2": "value2"}`),
+			templateType:   "Job Template",
+			expectErrors:   0,
+			expectWarnings: 0,
+		},
+		{
+			name: "missing required variable",
+			requirements: LaunchRequirements{
+				VariablesNeededToStart: []string{"survey_var1", "survey_var2"},
+			},
+			extraVarsValue: types.StringValue(`{"survey_var1": "value1"}`),
+			templateType:   "Job Template",
+			expectErrors:   1,
+			expectWarnings: 0,
+			errorContains:  "survey_var2",
+		},
+		{
+			name: "invalid JSON in extra_vars",
+			requirements: LaunchRequirements{
+				VariablesNeededToStart: []string{"survey_var1"},
+			},
+			extraVarsValue:  types.StringValue(`{invalid json`),
+			templateType:    "Job Template",
+			expectErrors:    0,
+			expectWarnings:  1,
+			warningContains: "Could not parse extra_vars as JSON",
+		},
+		{
+			name: "null extra_vars with required variables",
+			requirements: LaunchRequirements{
+				VariablesNeededToStart: []string{"survey_var1"},
+			},
+			extraVarsValue: types.StringNull(),
+			templateType:   "Job Template",
+			expectErrors:   1,
+			expectWarnings: 0,
+			errorContains:  "survey_var1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			diags := validateSurveyVariables(test.requirements, test.extraVarsValue, test.templateType)
+
+			if len(diags.Errors()) != test.expectErrors {
+				t.Errorf("Expected %d errors, but got %d: %v", test.expectErrors, len(diags.Errors()), diags.Errors())
+			}
+
+			if len(diags.Warnings()) != test.expectWarnings {
+				t.Errorf("Expected %d warnings, but got %d: %v", test.expectWarnings, len(diags.Warnings()), diags.Warnings())
+			}
+
+			if test.errorContains != "" {
+				found := false
+				for _, err := range diags.Errors() {
+					if regexp.MustCompile(test.errorContains).MatchString(err.Detail()) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected error to contain %q, but got: %v", test.errorContains, diags.Errors())
+				}
+			}
+
+			if test.warningContains != "" {
+				found := false
+				for _, warn := range diags.Warnings() {
+					if regexp.MustCompile(test.warningContains).MatchString(warn.Detail()) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected warning to contain %q, but got: %v", test.warningContains, diags.Warnings())
 				}
 			}
 		})

--- a/internal/provider/workflow_job_launch_action_test.go
+++ b/internal/provider/workflow_job_launch_action_test.go
@@ -178,12 +178,12 @@ func TestAccAAPWorkflowJobAction_AllFieldsOnPrompt(t *testing.T) {
 	})
 }
 
-// TestAccAAPWorkflowJobAction_AllFieldsOnPrompt_MissingRequired tests that a workflow job action with all
-// fields on prompt fails when required fields are not provided.
+// TestAccAAPWorkflowJobAction_AllFieldsOnPrompt_MissingRequired tests that a workflow job action with
+// required survey fields fails when required fields are not provided.
 func TestAccAAPWorkflowJobAction_AllFieldsOnPrompt_MissingRequired(t *testing.T) {
-	workflowJobTemplateID := os.Getenv("AAP_TEST_WORKFLOW_JOB_TEMPLATE_ALL_FIELDS_PROMPT_ID")
+	workflowJobTemplateID := os.Getenv("AAP_TEST_WORKFLOW_JOB_TEMPLATE_WITH_SURVEY_ID")
 	if workflowJobTemplateID == "" {
-		t.Skip("AAP_TEST_WORKFLOW_JOB_TEMPLATE_ALL_FIELDS_PROMPT_ID environment variable not set")
+		t.Skip("AAP_TEST_WORKFLOW_JOB_TEMPLATE_WITH_SURVEY_ID environment variable not set")
 	}
 	randNum, _ := rand.Int(rand.Reader, big.NewInt(50000000))
 	inventoryName := fmt.Sprintf("%s-%d", "tf-acc", randNum.Int64())

--- a/internal/provider/workflow_job_resource.go
+++ b/internal/provider/workflow_job_resource.go
@@ -383,7 +383,7 @@ func (r *WorkflowJobModel) CanWorkflowJobBeLaunched(client ProviderHTTPClient) (
 		{launchConfig.AskLabelsOnLaunch, r.Labels, "labels"},
 	}
 
-	diags.Append(ValidateLaunchFields(validations, "Workflow Job Template")...)
+	diags.Append(ValidateLaunchFields(launchConfig.VariablesNeededToStart, validations, "Workflow Job Template")...)
 	return diags
 }
 

--- a/internal/provider/workflow_job_resource.go
+++ b/internal/provider/workflow_job_resource.go
@@ -37,14 +37,16 @@ type WorkflowJobAPIModel struct {
 // GET /api/controller/v2/workflow_job_templates/<id>/launch/
 // It helps determine if a workflow_job_template can be launched.
 type WorkflowJobLaunchAPIModel struct {
-	AskVariablesOnLaunch   bool     `json:"ask_variables_on_launch"`
-	AskTagsOnLaunch        bool     `json:"ask_tags_on_launch"`
-	AskSkipTagsOnLaunch    bool     `json:"ask_skip_tags_on_launch"`
-	AskLimitOnLaunch       bool     `json:"ask_limit_on_launch"`
-	AskInventoryOnLaunch   bool     `json:"ask_inventory_on_launch"`
-	AskLabelsOnLaunch      bool     `json:"ask_labels_on_launch"`
-	SurveyEnabled          bool     `json:"survey_enabled"`
-	VariablesNeededToStart []string `json:"variables_needed_to_start"`
+	AskVariablesOnLaunch    bool     `json:"ask_variables_on_launch"`
+	AskTagsOnLaunch         bool     `json:"ask_tags_on_launch"`
+	AskSkipTagsOnLaunch     bool     `json:"ask_skip_tags_on_launch"`
+	AskLimitOnLaunch        bool     `json:"ask_limit_on_launch"`
+	AskInventoryOnLaunch    bool     `json:"ask_inventory_on_launch"`
+	AskLabelsOnLaunch       bool     `json:"ask_labels_on_launch"`
+	SurveyEnabled           bool     `json:"survey_enabled"`
+	VariablesNeededToStart  []string `json:"variables_needed_to_start"`
+	InventoryNeededToStart  bool     `json:"inventory_needed_to_start"`
+	CredentialNeededToStart bool     `json:"credential_needed_to_start"`
 }
 
 // WorkflowJobLaunchRequestModel represents the request body for POST /workflow_job_templates/{id}/launch.
@@ -383,7 +385,13 @@ func (r *WorkflowJobModel) CanWorkflowJobBeLaunched(client ProviderHTTPClient) (
 		{launchConfig.AskLabelsOnLaunch, r.Labels, "labels"},
 	}
 
-	diags.Append(ValidateLaunchFields(launchConfig.VariablesNeededToStart, validations, "Workflow Job Template")...)
+	requirements := LaunchRequirements{
+		VariablesNeededToStart:  launchConfig.VariablesNeededToStart,
+		InventoryNeededToStart:  launchConfig.InventoryNeededToStart,
+		CredentialNeededToStart: launchConfig.CredentialNeededToStart,
+	}
+
+	diags.Append(ValidateLaunchFields(requirements, validations, "Workflow Job Template", r.ExtraVars)...)
 	return diags
 }
 

--- a/internal/provider/workflow_job_resource_test.go
+++ b/internal/provider/workflow_job_resource_test.go
@@ -535,7 +535,7 @@ func TestWorkflowJobModelCanWorkflowJobBeLaunched(t *testing.T) {
 		// extra_vars
 		{
 			name:         "extra_vars required but not provided",
-			launchConfig: WorkflowJobLaunchAPIModel{AskVariablesOnLaunch: true},
+			launchConfig: WorkflowJobLaunchAPIModel{AskVariablesOnLaunch: true, VariablesNeededToStart: []string{"extra_vars"}},
 			model:        WorkflowJobModel{TemplateID: types.Int64Value(1), ExtraVars: customtypes.NewAAPCustomStringNull()},
 			expectError:  true,
 		},
@@ -548,7 +548,7 @@ func TestWorkflowJobModelCanWorkflowJobBeLaunched(t *testing.T) {
 		// inventory_id
 		{
 			name:         "inventory_id required but not provided",
-			launchConfig: WorkflowJobLaunchAPIModel{AskInventoryOnLaunch: true},
+			launchConfig: WorkflowJobLaunchAPIModel{AskInventoryOnLaunch: true, VariablesNeededToStart: []string{"inventory"}},
 			model:        WorkflowJobModel{TemplateID: types.Int64Value(1), InventoryID: types.Int64Null()},
 			expectError:  true,
 		},
@@ -561,7 +561,7 @@ func TestWorkflowJobModelCanWorkflowJobBeLaunched(t *testing.T) {
 		// limit
 		{
 			name:         "limit required but not provided",
-			launchConfig: WorkflowJobLaunchAPIModel{AskLimitOnLaunch: true},
+			launchConfig: WorkflowJobLaunchAPIModel{AskLimitOnLaunch: true, VariablesNeededToStart: []string{"limit"}},
 			model:        WorkflowJobModel{TemplateID: types.Int64Value(1), Limit: customtypes.NewAAPCustomStringNull()},
 			expectError:  true,
 		},
@@ -574,7 +574,7 @@ func TestWorkflowJobModelCanWorkflowJobBeLaunched(t *testing.T) {
 		// job_tags
 		{
 			name:         "job_tags required but not provided",
-			launchConfig: WorkflowJobLaunchAPIModel{AskTagsOnLaunch: true},
+			launchConfig: WorkflowJobLaunchAPIModel{AskTagsOnLaunch: true, VariablesNeededToStart: []string{"job_tags"}},
 			model:        WorkflowJobModel{TemplateID: types.Int64Value(1), JobTags: customtypes.NewAAPCustomStringNull()},
 			expectError:  true,
 		},
@@ -587,7 +587,7 @@ func TestWorkflowJobModelCanWorkflowJobBeLaunched(t *testing.T) {
 		// skip_tags
 		{
 			name:         "skip_tags required but not provided",
-			launchConfig: WorkflowJobLaunchAPIModel{AskSkipTagsOnLaunch: true},
+			launchConfig: WorkflowJobLaunchAPIModel{AskSkipTagsOnLaunch: true, VariablesNeededToStart: []string{"skip_tags"}},
 			model:        WorkflowJobModel{TemplateID: types.Int64Value(1), SkipTags: customtypes.NewAAPCustomStringNull()},
 			expectError:  true,
 		},
@@ -600,7 +600,7 @@ func TestWorkflowJobModelCanWorkflowJobBeLaunched(t *testing.T) {
 		// labels
 		{
 			name:         "labels required but not provided",
-			launchConfig: WorkflowJobLaunchAPIModel{AskLabelsOnLaunch: true},
+			launchConfig: WorkflowJobLaunchAPIModel{AskLabelsOnLaunch: true, VariablesNeededToStart: []string{"labels"}},
 			model:        WorkflowJobModel{TemplateID: types.Int64Value(1), Labels: types.ListNull(types.Int64Type)},
 			expectError:  true,
 		},
@@ -614,10 +614,11 @@ func TestWorkflowJobModelCanWorkflowJobBeLaunched(t *testing.T) {
 		{
 			name: "all required fields provided - no errors",
 			launchConfig: WorkflowJobLaunchAPIModel{
-				AskVariablesOnLaunch: true,
-				AskLimitOnLaunch:     true,
-				AskInventoryOnLaunch: true,
-				AskLabelsOnLaunch:    true,
+				AskVariablesOnLaunch:   true,
+				AskLimitOnLaunch:       true,
+				AskInventoryOnLaunch:   true,
+				AskLabelsOnLaunch:      true,
+				VariablesNeededToStart: []string{"extra_vars", "limit", "inventory", "labels"},
 			},
 			model: WorkflowJobModel{
 				TemplateID:  types.Int64Value(1),
@@ -691,7 +692,8 @@ func TestWorkflowJobModelLaunchWorkflowJob(t *testing.T) {
 				ExtraVars:  customtypes.NewAAPCustomStringNull(),
 			},
 			launchConfig: WorkflowJobLaunchAPIModel{
-				AskVariablesOnLaunch: true, // extra_vars required but not provided
+				AskVariablesOnLaunch:   true,
+				VariablesNeededToStart: []string{"extra_vars"}, // extra_vars required but not provided
 			},
 			expectError:  true,
 			skipPostMock: true,
@@ -1118,12 +1120,12 @@ func TestAccAAPWorkflowJob_AllFieldsOnPrompt(t *testing.T) {
 	})
 }
 
-// TestAccAAPWorkflowJob_AllFieldsOnPrompt_MissingRequired tests that a workflow job resource with all
-// fields on prompt fails when required fields are not provided.
+// TestAccAAPWorkflowJob_AllFieldsOnPrompt_MissingRequired tests that a workflow job resource with
+// required survey fields fails when required fields are not provided.
 func TestAccAAPWorkflowJob_AllFieldsOnPrompt_MissingRequired(t *testing.T) {
-	workflowJobTemplateID := os.Getenv("AAP_TEST_WORKFLOW_JOB_TEMPLATE_ALL_FIELDS_PROMPT_ID")
+	workflowJobTemplateID := os.Getenv("AAP_TEST_WORKFLOW_JOB_TEMPLATE_WITH_SURVEY_ID")
 	if workflowJobTemplateID == "" {
-		t.Skip("AAP_TEST_WORKFLOW_JOB_TEMPLATE_ALL_FIELDS_PROMPT_ID environment variable not set")
+		t.Skip("AAP_TEST_WORKFLOW_JOB_TEMPLATE_WITH_SURVEY_ID environment variable not set")
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/workflow_job_resource_test.go
+++ b/internal/provider/workflow_job_resource_test.go
@@ -612,13 +612,14 @@ func TestWorkflowJobModelCanWorkflowJobBeLaunched(t *testing.T) {
 		},
 		// Combined success case
 		{
-			name: "all required fields provided - no errors",
+			name: "template fields allowed and provided - no errors",
 			launchConfig: WorkflowJobLaunchAPIModel{
-				AskVariablesOnLaunch:   true,
-				AskLimitOnLaunch:       true,
-				AskInventoryOnLaunch:   true,
-				AskLabelsOnLaunch:      true,
-				VariablesNeededToStart: []string{"extra_vars", "limit", "inventory", "labels"},
+				AskVariablesOnLaunch:    true,
+				AskLimitOnLaunch:        true,
+				AskInventoryOnLaunch:    true,
+				AskLabelsOnLaunch:       true,
+				InventoryNeededToStart:  false,
+				CredentialNeededToStart: false,
 			},
 			model: WorkflowJobModel{
 				TemplateID:  types.Int64Value(1),

--- a/internal/provider/workflow_job_resource_test.go
+++ b/internal/provider/workflow_job_resource_test.go
@@ -532,11 +532,25 @@ func TestWorkflowJobModelCanWorkflowJobBeLaunched(t *testing.T) {
 			model:        WorkflowJobModel{TemplateID: types.Int64Value(1)},
 			expectError:  false,
 		},
-		// extra_vars
+		// Regression test for bug fix: ask_on_launch=true does NOT mean field is required
 		{
-			name:         "extra_vars required but not provided",
-			launchConfig: WorkflowJobLaunchAPIModel{AskVariablesOnLaunch: true, VariablesNeededToStart: []string{"extra_vars"}},
-			model:        WorkflowJobModel{TemplateID: types.Int64Value(1), ExtraVars: customtypes.NewAAPCustomStringNull()},
+			name: "ask_on_launch true but field not required - no error",
+			launchConfig: WorkflowJobLaunchAPIModel{
+				AskInventoryOnLaunch:    true,  // Field CAN be provided
+				InventoryNeededToStart:  false, // But it's NOT required
+				CredentialNeededToStart: false,
+			},
+			model: WorkflowJobModel{
+				TemplateID:  types.Int64Value(1),
+				InventoryID: types.Int64Null(), // Not provided - should be OK
+			},
+			expectError: false, // This is the bug fix - old code would error here
+		},
+		// Survey variables (in extra_vars)
+		{
+			name:         "survey variable required but not provided in extra_vars",
+			launchConfig: WorkflowJobLaunchAPIModel{AskVariablesOnLaunch: true, VariablesNeededToStart: []string{"my_survey_var"}},
+			model:        WorkflowJobModel{TemplateID: types.Int64Value(1), ExtraVars: customtypes.NewAAPCustomStringValue(`{}`)},
 			expectError:  true,
 		},
 		{
@@ -548,7 +562,7 @@ func TestWorkflowJobModelCanWorkflowJobBeLaunched(t *testing.T) {
 		// inventory_id
 		{
 			name:         "inventory_id required but not provided",
-			launchConfig: WorkflowJobLaunchAPIModel{AskInventoryOnLaunch: true, VariablesNeededToStart: []string{"inventory"}},
+			launchConfig: WorkflowJobLaunchAPIModel{AskInventoryOnLaunch: true, InventoryNeededToStart: true},
 			model:        WorkflowJobModel{TemplateID: types.Int64Value(1), InventoryID: types.Int64Null()},
 			expectError:  true,
 		},
@@ -558,52 +572,28 @@ func TestWorkflowJobModelCanWorkflowJobBeLaunched(t *testing.T) {
 			model:          WorkflowJobModel{TemplateID: types.Int64Value(1), InventoryID: types.Int64Value(10)},
 			expectWarnings: true,
 		},
-		// limit
-		{
-			name:         "limit required but not provided",
-			launchConfig: WorkflowJobLaunchAPIModel{AskLimitOnLaunch: true, VariablesNeededToStart: []string{"limit"}},
-			model:        WorkflowJobModel{TemplateID: types.Int64Value(1), Limit: customtypes.NewAAPCustomStringNull()},
-			expectError:  true,
-		},
+		// limit (can only be optional at template level, never required)
 		{
 			name:           "limit provided but not expected - warning",
 			launchConfig:   WorkflowJobLaunchAPIModel{AskLimitOnLaunch: false},
 			model:          WorkflowJobModel{TemplateID: types.Int64Value(1), Limit: customtypes.NewAAPCustomStringValue("all")},
 			expectWarnings: true,
 		},
-		// job_tags
-		{
-			name:         "job_tags required but not provided",
-			launchConfig: WorkflowJobLaunchAPIModel{AskTagsOnLaunch: true, VariablesNeededToStart: []string{"job_tags"}},
-			model:        WorkflowJobModel{TemplateID: types.Int64Value(1), JobTags: customtypes.NewAAPCustomStringNull()},
-			expectError:  true,
-		},
+		// job_tags (can only be optional at template level, never required)
 		{
 			name:           "job_tags provided but not expected - warning",
 			launchConfig:   WorkflowJobLaunchAPIModel{AskTagsOnLaunch: false},
 			model:          WorkflowJobModel{TemplateID: types.Int64Value(1), JobTags: customtypes.NewAAPCustomStringValue("deploy")},
 			expectWarnings: true,
 		},
-		// skip_tags
-		{
-			name:         "skip_tags required but not provided",
-			launchConfig: WorkflowJobLaunchAPIModel{AskSkipTagsOnLaunch: true, VariablesNeededToStart: []string{"skip_tags"}},
-			model:        WorkflowJobModel{TemplateID: types.Int64Value(1), SkipTags: customtypes.NewAAPCustomStringNull()},
-			expectError:  true,
-		},
+		// skip_tags (can only be optional at template level, never required)
 		{
 			name:           "skip_tags provided but not expected - warning",
 			launchConfig:   WorkflowJobLaunchAPIModel{AskSkipTagsOnLaunch: false},
 			model:          WorkflowJobModel{TemplateID: types.Int64Value(1), SkipTags: customtypes.NewAAPCustomStringValue("debug")},
 			expectWarnings: true,
 		},
-		// labels
-		{
-			name:         "labels required but not provided",
-			launchConfig: WorkflowJobLaunchAPIModel{AskLabelsOnLaunch: true, VariablesNeededToStart: []string{"labels"}},
-			model:        WorkflowJobModel{TemplateID: types.Int64Value(1), Labels: types.ListNull(types.Int64Type)},
-			expectError:  true,
-		},
+		// labels (can only be optional at template level, never required)
 		{
 			name:           "labels provided but not expected - warning",
 			launchConfig:   WorkflowJobLaunchAPIModel{AskLabelsOnLaunch: false},

--- a/testing/playbook.yml
+++ b/testing/playbook.yml
@@ -64,7 +64,29 @@
         ask_instance_groups_on_launch: true
         ask_timeout_on_launch: true
         ask_job_slice_count_on_launch: true
+        survey_enabled: false
       register: job_template_all_fields_on_prompt
+    # Create a separate template with a survey for testing MissingRequired validation
+    - name: Create Job Template with survey for required field validation
+      ansible.controller.job_template:
+        name: "Test Job Template - hello_world.yml with Survey"
+        organization: "Default"
+        project: "Demo Project"
+        playbook: "hello_world.yml"
+        ask_inventory_on_launch: true
+        survey_enabled: true
+        survey_spec:
+          name: ""
+          description: ""
+          spec:
+            - question_name: "Inventory"
+              question_description: "Required inventory"
+              required: true
+              type: "integer"
+              variable: "inventory"
+              min: 1
+              max: 999999
+      register: job_template_with_survey
     # Create a label for tests that need to provide labels at launch
     - name: Create test label
       ansible.controller.label:
@@ -104,7 +126,27 @@
         ask_limit_on_launch: true
         ask_inventory_on_launch: true
         ask_labels_on_launch: true
+        survey_enabled: false
       register: workflow_job_template_all_fields_on_prompt
+    # Create a separate workflow template with a survey for testing MissingRequired validation
+    - name: Create Workflow Job Template with survey for required field validation
+      ansible.controller.workflow_job_template:
+        name: "Demo Workflow Job Template with Survey"
+        organization: "Default"
+        ask_inventory_on_launch: true
+        survey_enabled: true
+        survey_spec:
+          name: ""
+          description: ""
+          spec:
+            - question_name: "Inventory"
+              question_description: "Required inventory"
+              required: true
+              type: "integer"
+              variable: "inventory"
+              min: 1
+              max: 999999
+      register: workflow_job_template_with_survey
     # The tests for resource.aap_inventory create an inventory that is in a non-default
     # organization. So we need an organization that is not 'Default'
     - name: Create non-default organization

--- a/testing/templates/acceptance_test_vars.env.j2
+++ b/testing/templates/acceptance_test_vars.env.j2
@@ -1,9 +1,11 @@
 export AAP_TEST_JOB_TEMPLATE_ID="{{ job_template.id }}"
 export AAP_TEST_JOB_TEMPLATE_INVENTORY_PROMPT_ID="{{ job_template_inventory_prompt_on_launch.id }}"
 export AAP_TEST_JOB_TEMPLATE_ALL_FIELDS_PROMPT_ID="{{ job_template_all_fields_on_prompt.id }}"
+export AAP_TEST_JOB_TEMPLATE_WITH_SURVEY_ID="{{ job_template_with_survey.id }}"
 export AAP_TEST_WORKFLOW_JOB_TEMPLATE_ID="{{ workflow_job_template.id }}"
 export AAP_TEST_WORKFLOW_JOB_TEMPLATE_FAIL_ID="{{ workflow_job_template_failure.id }}"
 export AAP_TEST_WORKFLOW_JOB_TEMPLATE_ALL_FIELDS_PROMPT_ID="{{ workflow_job_template_all_fields_on_prompt.id }}"
+export AAP_TEST_WORKFLOW_JOB_TEMPLATE_WITH_SURVEY_ID="{{ workflow_job_template_with_survey.id }}"
 export AAP_TEST_ORGANIZATION_ID="{{ organization_non_default.id }}"
 
 export AAP_TEST_WORKFLOW_INVENTORY_ID="{{ workflow_with_inventory.id }}"


### PR DESCRIPTION
<!-- 
Thank you for contributing to terraform-provider-aap!

Please review our contribution guidelines: 
https://github.com/ansible/terraform-provider-aap/blob/main/CONTRIBUTING.md
-->

## Description

Issue: 
Validation logic treated `ask_*_on_launch = true` as "field is required" when it actually means "field can be overridden (optional)", causing 8 workflow job tests to fail with false "Missing required field" errors.                                                   

The bug existed from the initial implementation of prompt-on-launch fields, it was masked in job templates because they were configured with defaults for all `ask_*_on_launch` fields. Workflow templates were the first to have `ask_*_on_launch = true` without defaults.
                  
Fix:        
Use AAP's `/launch/` endpoint response as the authoritative source for validation:              
   
  1. Template field validation using explicit boolean flags from AAP:                           
    - `inventory_needed_to_start` (boolean) → validates inventory_id template field
    - `credential_needed_to_start` (boolean) → validates credentials template field               
  2. Survey variable validation by parsing extra_vars JSON:                                     
    - `variables_needed_to_start` (array) contains survey variable names (e.g., "app_version", "environment")                                                                                
    - Parse extra_vars JSON and verify each variable in `variables_needed_to_start` exists
    - Gracefully handles JSON parsing errors with warnings                                      
  3. Ignored field warnings (existing functionality):       
    - Warns when fields are provided but template doesn't allow them at launch (`ask_*_on_launch = false`)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing Checklist

### Unit Tests

- [x] Unit tests added/updated for new code
- [x] All unit tests pass locally (`make test`)
- [x] Verified coverage locally (`make testcov`)

**Note:** SonarQube will automatically verify ≥80% coverage on new code in CI.

**Check your PR coverage:** [SonarCloud - terraform-provider-aap](https://sonarcloud.io/project/overview?id=ansible_terraform-provider-aap)

### Acceptance Tests

- [x] Acceptance tests added/updated
- [x] Acceptance tests pass (see output below)
See https://redhat.atlassian.net/browse/AAP-71523 attachments for acceptance test output


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved launch validation for job and workflow templates to correctly treat survey-declared requirements (variables, inventory, credentials) as required at launch, reducing false positives/negatives.

* **Tests**
  * Updated acceptance and unit tests plus test templates to cover survey-driven required-field scenarios, including new survey-enabled templates and validations for missing or invalid extra_vars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->